### PR TITLE
feat: Change speak tool to require pre-split text array as input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,9 @@ server.tool(
   "Convert text to speech and play it",
   {
     text: z
-      .string()
+      .array(z.string())
       .describe(
-        "Text to be spoken (if both query and text are provided, query takes precedence)"
+        "Provide an array of sentences to synthesize and play in order. For faster playback start, it is recommended to make the first element short."
       ),
     speaker: z
       .number()
@@ -182,7 +182,6 @@ server.connect(new StdioServerTransport()).catch((error) => {
   process.exit(1);
 });
 
-// 型定義のエクスポート（モジュールとして使用する場合）
 export {
   AudioQuery,
   VoicevoxConfig,

--- a/src/voicevox/index.ts
+++ b/src/voicevox/index.ts
@@ -22,21 +22,25 @@ export class VoicevoxClient {
 
   /**
    * テキストを音声に変換して再生します
-   * @param text 変換するテキスト
+   * @param text 変換するテキストまたはテキストの配列
    * @param speaker 話者ID（オプション）
    * @param speedScale 再生速度（オプション）
    * @returns 処理結果のメッセージ
    */
   public async speak(
-    text: string,
+    text: string | string[],
     speaker?: number,
     speedScale?: number
   ): Promise<string> {
     try {
       const speakerId = this.getSpeakerId(speaker);
       const speed = this.getSpeedScale(speedScale);
-      const segments = splitText(text, this.maxSegmentLength);
       const queueManager = this.player.getQueueManager();
+
+      // 文字列配列の場合は直接使用、文字列の場合は分割して配列に変換
+      const segments = Array.isArray(text)
+        ? text
+        : splitText(text, this.maxSegmentLength);
 
       if (segments.length === 0) {
         return "テキストが空です";
@@ -66,7 +70,9 @@ export class VoicevoxClient {
         });
       }
 
-      return `音声生成キューに追加しました: ${text}`;
+      return `音声生成キューに追加しました: ${
+        Array.isArray(text) ? text.join(" ") : text
+      }`;
     } catch (error) {
       return formatError("音声生成中にエラーが発生しました", error);
     }


### PR DESCRIPTION
- The 'text' parameter now only accepts an array of strings (no longer accepts a single string)
- Removed server-side text splitting; clients must now split text in advance
- Updated the description to clarify the new requirement