### PR TITLE
feat: キュークリア機能の追加とREADMEの更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ await client.speak("こんにちは");
 
 // テキストから音声ファイルを生成
 const filePath = await client.generateAudioFile("こんにちは", "./output.wav");
+
+// キューをクリア
+await client.clearQueue();
 ```
 
 ## 主な機能
@@ -59,10 +62,13 @@ const filePath = await client.generateAudioFile("こんにちは", "./output.wav
 - **テキスト読み上げ** (`speak`) - テキストを音声に変換して再生
 - **クエリ生成** (`generate_query`) - 音声合成用クエリの作成
 - **ファイル生成** (`synthesize_file`) - クエリから音声ファイルを生成
+- **キュークリア** (`clear_queue`) - 現在の音声合成キューをすべてクリア
 
 ## 環境変数
 
 - `VOICEVOX_URL`: VOICEVOXエンジンのURL（デフォルト: `http://localhost:50021`）
+- `VOICEVOX_DEFAULT_SPEAKER`: デフォルト話者ID（例: `1`）
+- `VOICEVOX_DEFAULT_SPEED_SCALE`: デフォルト再生速度（例: `1.0`）
 
 ## ライセンス
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,23 @@ server.tool(
   }
 );
 
+// キュークリアツール
+server.tool(
+  "clear_queue",
+  "Clear the current synthesis queue",
+  {},
+  async () => {
+    try {
+      await voicevoxClient.clearQueue();
+      return {
+        content: [{ type: "text", text: "キューをクリアしました" }],
+      };
+    } catch (error) {
+      return handleError(error);
+    }
+  }
+);
+
 server.connect(new StdioServerTransport()).catch((error) => {
   console.error("Error connecting to MCP transport:", error);
   process.exit(1);

--- a/src/voicevox/index.ts
+++ b/src/voicevox/index.ts
@@ -270,6 +270,13 @@ export class VoicevoxClient {
       throw new Error("無効なVOICEVOXのURLです");
     }
   }
+
+  /**
+   * キューをクリア
+   */
+  public async clearQueue(): Promise<void> {
+    return this.player.clearQueue();
+  }
 }
 
 // 型定義の再エクスポート

--- a/src/voicevox/player.ts
+++ b/src/voicevox/player.ts
@@ -176,4 +176,13 @@ export class VoicevoxPlayer {
   public getQueueManager(): VoicevoxQueueManager {
     return this.queueManager;
   }
+
+  /**
+   * キューをクリア
+   */
+  public async clearQueue(): Promise<void> {
+    return withErrorHandling(async () => {
+      await this.queueManager.clearQueue();
+    }, "キューのクリア中にエラーが発生しました");
+  }
 }


### PR DESCRIPTION
- MCPツールとしてキューをクリアする clear_queue を追加
- VoicevoxClient/Playerに clearQueue メソッドを実装
- READMEに「キュークリア」機能の説明とサンプルコードを追加
- 環境変数 VOICEVOX_DEFAULT_SPEAKER, VOICEVOX_DEFAULT_SPEED_SCALE の説明をREADMEに追記