### PR TITLE
Change speak tool to require pre-split text array and add clear queue feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ await client.speak("こんにちは");
 
 // テキストから音声ファイルを生成
 const filePath = await client.generateAudioFile("こんにちは", "./output.wav");
+
+// キューをクリア
+await client.clearQueue();
 ```
 
 ## 主な機能
@@ -59,10 +62,13 @@ const filePath = await client.generateAudioFile("こんにちは", "./output.wav
 - **テキスト読み上げ** (`speak`) - テキストを音声に変換して再生
 - **クエリ生成** (`generate_query`) - 音声合成用クエリの作成
 - **ファイル生成** (`synthesize_file`) - クエリから音声ファイルを生成
+- **キュークリア** (`clear_queue`) - 現在の音声合成キューをすべてクリア
 
 ## 環境変数
 
 - `VOICEVOX_URL`: VOICEVOXエンジンのURL（デフォルト: `http://localhost:50021`）
+- `VOICEVOX_DEFAULT_SPEAKER`: デフォルト話者ID（例: `1`）
+- `VOICEVOX_DEFAULT_SPEED_SCALE`: デフォルト再生速度（例: `1.0`）
 
 ## ライセンス
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajidog/mcp-tts-voicevox",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "VOICEVOX integration for MCP - Text-to-Speech server using VOICEVOX engine",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 
 const server = new McpServer({
   name: "MCP TTS Voicevox",
-  version: "0.0.8",
+  version: "0.0.9",
   description:
     "A Voicevox server that converts text to speech for playback and saving.",
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,9 @@ server.tool(
   "Convert text to speech and play it",
   {
     text: z
-      .string()
+      .array(z.string())
       .describe(
-        "Text to be spoken (if both query and text are provided, query takes precedence)"
+        "Provide an array of sentences to synthesize and play in order. For faster playback start, it is recommended to make the first element short."
       ),
     speaker: z
       .number()
@@ -182,7 +182,6 @@ server.connect(new StdioServerTransport()).catch((error) => {
   process.exit(1);
 });
 
-// 型定義のエクスポート（モジュールとして使用する場合）
 export {
   AudioQuery,
   VoicevoxConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,23 @@ server.tool(
   }
 );
 
+// キュークリアツール
+server.tool(
+  "clear_queue",
+  "Clear the current synthesis queue",
+  {},
+  async () => {
+    try {
+      await voicevoxClient.clearQueue();
+      return {
+        content: [{ type: "text", text: "キューをクリアしました" }],
+      };
+    } catch (error) {
+      return handleError(error);
+    }
+  }
+);
+
 server.connect(new StdioServerTransport()).catch((error) => {
   console.error("Error connecting to MCP transport:", error);
   process.exit(1);

--- a/src/voicevox/index.ts
+++ b/src/voicevox/index.ts
@@ -270,6 +270,13 @@ export class VoicevoxClient {
       throw new Error("無効なVOICEVOXのURLです");
     }
   }
+
+  /**
+   * キューをクリア
+   */
+  public async clearQueue(): Promise<void> {
+    return this.player.clearQueue();
+  }
 }
 
 // 型定義の再エクスポート

--- a/src/voicevox/index.ts
+++ b/src/voicevox/index.ts
@@ -22,21 +22,25 @@ export class VoicevoxClient {
 
   /**
    * テキストを音声に変換して再生します
-   * @param text 変換するテキスト
+   * @param text 変換するテキストまたはテキストの配列
    * @param speaker 話者ID（オプション）
    * @param speedScale 再生速度（オプション）
    * @returns 処理結果のメッセージ
    */
   public async speak(
-    text: string,
+    text: string | string[],
     speaker?: number,
     speedScale?: number
   ): Promise<string> {
     try {
       const speakerId = this.getSpeakerId(speaker);
       const speed = this.getSpeedScale(speedScale);
-      const segments = splitText(text, this.maxSegmentLength);
       const queueManager = this.player.getQueueManager();
+
+      // 文字列配列の場合は直接使用、文字列の場合は分割して配列に変換
+      const segments = Array.isArray(text)
+        ? text
+        : splitText(text, this.maxSegmentLength);
 
       if (segments.length === 0) {
         return "テキストが空です";
@@ -66,7 +70,9 @@ export class VoicevoxClient {
         });
       }
 
-      return `音声生成キューに追加しました: ${text}`;
+      return `音声生成キューに追加しました: ${
+        Array.isArray(text) ? text.join(" ") : text
+      }`;
     } catch (error) {
       return formatError("音声生成中にエラーが発生しました", error);
     }

--- a/src/voicevox/player.ts
+++ b/src/voicevox/player.ts
@@ -176,4 +176,13 @@ export class VoicevoxPlayer {
   public getQueueManager(): VoicevoxQueueManager {
     return this.queueManager;
   }
+
+  /**
+   * キューをクリア
+   */
+  public async clearQueue(): Promise<void> {
+    return withErrorHandling(async () => {
+      await this.queueManager.clearQueue();
+    }, "キューのクリア中にエラーが発生しました");
+  }
 }


### PR DESCRIPTION
Update the speak tool to accept only an array of strings as input, removing server-side text splitting. Introduce a new clear queue feature and update the README to reflect these changes, including environment variable descriptions.