### PR TITLE
feat: add configurable API timeout and retry support

### DIFF
--- a/apps/mcp-tts/src/config.ts
+++ b/apps/mcp-tts/src/config.ts
@@ -197,6 +197,33 @@ const voicevoxConfigDefs: ConfigDefs = {
     default: '',
     valueName: '<domain>',
   },
+  apiTimeout: {
+    cli: '--api-timeout',
+    env: 'VOICEVOX_API_TIMEOUT',
+    description: 'API request timeout in milliseconds',
+    group: 'Voicevox Configuration',
+    type: 'number',
+    default: 30000,
+    valueName: '<ms>',
+  },
+  apiRetryCount: {
+    cli: '--api-retry-count',
+    env: 'VOICEVOX_API_RETRY_COUNT',
+    description: 'Number of retries on transient API errors (timeout/network failure)',
+    group: 'Voicevox Configuration',
+    type: 'number',
+    default: 0,
+    valueName: '<count>',
+  },
+  apiRetryDelay: {
+    cli: '--api-retry-delay',
+    env: 'VOICEVOX_API_RETRY_DELAY',
+    description: 'Delay in milliseconds between API retries',
+    group: 'Voicevox Configuration',
+    type: 'number',
+    default: 1000,
+    valueName: '<ms>',
+  },
   configFile: {
     cli: '--config',
     env: 'VOICEVOX_CONFIG',
@@ -220,6 +247,9 @@ export interface ServerConfig extends BaseServerConfig {
   defaultSpeaker: number
   defaultSpeedScale: number
   useStreaming?: boolean
+  apiTimeout: number
+  apiRetryCount: number
+  apiRetryDelay: number
 
   // 再生オプションのデフォルト
   defaultImmediate: boolean

--- a/apps/mcp-tts/src/server.ts
+++ b/apps/mcp-tts/src/server.ts
@@ -29,6 +29,9 @@ export function createServer(): McpServer {
     defaultSpeaker: config.defaultSpeaker,
     defaultSpeedScale: config.defaultSpeedScale,
     useStreaming: config.useStreaming,
+    apiTimeout: config.apiTimeout,
+    apiRetryCount: config.apiRetryCount,
+    apiRetryDelay: config.apiRetryDelay,
   })
 
   // 共通依存オブジェクト

--- a/packages/voicevox-client/src/__tests__/api-timeout-retry.test.ts
+++ b/packages/voicevox-client/src/__tests__/api-timeout-retry.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VoicevoxApi } from '../api'
+
+const BASE_URL = 'http://localhost:50021'
+
+function makeTimeoutError(): DOMException {
+  return new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+}
+
+function makeAbortError(): DOMException {
+  return new DOMException('The operation was aborted', 'AbortError')
+}
+
+function makeNetworkError(): TypeError {
+  return new TypeError('Failed to fetch')
+}
+
+describe('VoicevoxApi - timeout and retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('timeout configuration', () => {
+    it('デフォルトのタイムアウト（30秒）を使用する', async () => {
+      const api = new VoicevoxApi(BASE_URL)
+      const abortSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(new AbortController().signal)
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('1', { status: 200 }))
+
+      await api.checkHealth()
+
+      expect(abortSpy).toHaveBeenCalledWith(30000)
+    })
+
+    it('カスタムタイムアウトを使用する', async () => {
+      const api = new VoicevoxApi(BASE_URL, { timeout: 5000 })
+      const abortSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(new AbortController().signal)
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('1', { status: 200 }))
+
+      await api.checkHealth()
+
+      expect(abortSpy).toHaveBeenCalledWith(5000)
+    })
+  })
+
+  describe('retry on transient errors', () => {
+    it('タイムアウトエラー時にリトライする', async () => {
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 2, retryDelay: 100 })
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(makeTimeoutError())
+        .mockRejectedValueOnce(makeTimeoutError())
+        .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+      const promise = api.getSpeakers()
+      await vi.runAllTimersAsync()
+      const result = await promise
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(result).toEqual([])
+    })
+
+    it('AbortErrorエラー時にリトライする', async () => {
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 1, retryDelay: 100 })
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(makeAbortError())
+        .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+      const promise = api.getSpeakers()
+      await vi.runAllTimersAsync()
+      const result = await promise
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      expect(result).toEqual([])
+    })
+
+    it('ネットワークエラー時にリトライする', async () => {
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 1, retryDelay: 100 })
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(makeNetworkError())
+        .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+      const promise = api.getSpeakers()
+      await vi.runAllTimersAsync()
+      const result = await promise
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      expect(result).toEqual([])
+    })
+
+    it('リトライ回数を超えたらエラーをスローする', async () => {
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 2, retryDelay: 100 })
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(makeTimeoutError())
+
+      const promise = api.getSpeakers()
+      // リジェクション未処理警告を防ぐため先にキャッチャーを登録
+      const caught = promise.catch((e) => e)
+      await vi.runAllTimersAsync()
+      const error = await caught
+
+      // 初回 + 2回リトライ = 計3回
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('no retry on non-transient errors', () => {
+    it('HTTP 4xxエラーはリトライしない', async () => {
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 3, retryDelay: 100 })
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('Bad Request', { status: 400 }))
+
+      await expect(api.getSpeakers()).rejects.toThrow()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('HTTP 5xxエラーはリトライしない', async () => {
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 3, retryDelay: 100 })
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('Internal Server Error', { status: 500 }))
+
+      await expect(api.getSpeakers()).rejects.toThrow()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('retry delay', () => {
+    it('リトライ間隔を指定した時間待機する', async () => {
+      const retryDelay = 500
+      const api = new VoicevoxApi(BASE_URL, { retryCount: 1, retryDelay })
+      vi.spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(makeTimeoutError())
+        .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+      let resolved = false
+      const promise = api.getSpeakers().then((r) => {
+        resolved = true
+        return r
+      })
+
+      // 遅延前はまだ解決していない
+      await vi.advanceTimersByTimeAsync(retryDelay - 1)
+      expect(resolved).toBe(false)
+
+      // 遅延後に解決する
+      await vi.advanceTimersByTimeAsync(1)
+      await promise
+      expect(resolved).toBe(true)
+    })
+  })
+
+  describe('default behavior (no retry)', () => {
+    it('リトライ設定なしの場合、失敗時は即座にエラーをスローする', async () => {
+      const api = new VoicevoxApi(BASE_URL)
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(makeTimeoutError())
+
+      await expect(api.getSpeakers()).rejects.toThrow()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/voicevox-client/src/api.ts
+++ b/packages/voicevox-client/src/api.ts
@@ -3,9 +3,15 @@ import type { AccentPhrase, AudioQuery, Speaker, SpeakerInfo, UserDictionaryWord
 
 export class VoicevoxApi {
   private readonly baseUrl: string
+  private readonly timeout: number
+  private readonly retryCount: number
+  private readonly retryDelay: number
 
-  constructor(baseUrl: string) {
+  constructor(baseUrl: string, options?: { timeout?: number; retryCount?: number; retryDelay?: number }) {
     this.baseUrl = this.normalizeUrl(baseUrl)
+    this.timeout = options?.timeout ?? 30000
+    this.retryCount = options?.retryCount ?? 0
+    this.retryDelay = options?.retryDelay ?? 1000
   }
 
   /**
@@ -239,46 +245,67 @@ export class VoicevoxApi {
     headers: Record<string, string> = {},
     responseType: 'json' | 'arraybuffer' | 'text' = 'json'
   ): Promise<T> {
-    try {
-      const url = `${this.baseUrl}${endpoint}`
-      const init: RequestInit = {
-        method: method.toUpperCase(),
-        headers,
-        signal: AbortSignal.timeout(30000),
+    const url = `${this.baseUrl}${endpoint}`
+    let lastError: unknown
+
+    for (let attempt = 0; attempt <= this.retryCount; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, this.retryDelay))
       }
 
-      if (data !== null) {
-        init.body = JSON.stringify(data)
-      }
+      try {
+        const init: RequestInit = {
+          method: method.toUpperCase(),
+          headers,
+          signal: AbortSignal.timeout(this.timeout),
+        }
 
-      const response = await fetch(url, init)
+        if (data !== null) {
+          init.body = JSON.stringify(data)
+        }
 
-      if (!response.ok) {
-        throw new VoicevoxError(
-          `APIリクエストに失敗しました: ${response.status}`,
-          VoicevoxErrorCode.API_CONNECTION_ERROR
-        )
-      }
+        const response = await fetch(url, init)
 
-      if (responseType === 'arraybuffer') {
-        return (await response.arrayBuffer()) as T
+        if (!response.ok) {
+          throw new VoicevoxError(
+            `APIリクエストに失敗しました: ${response.status}`,
+            VoicevoxErrorCode.API_CONNECTION_ERROR
+          )
+        }
+
+        if (responseType === 'arraybuffer') {
+          return (await response.arrayBuffer()) as T
+        }
+        if (responseType === 'text') {
+          return (await response.text()) as T
+        }
+        if (response.status === 204) {
+          return null as T
+        }
+        return (await response.json()) as T
+      } catch (error) {
+        if (error instanceof VoicevoxError) {
+          throw error
+        }
+        // タイムアウトまたはネットワーク障害のみリトライ対象
+        const isTransient =
+          (error instanceof DOMException && (error.name === 'TimeoutError' || error.name === 'AbortError')) ||
+          error instanceof TypeError
+        if (!isTransient || attempt >= this.retryCount) {
+          throw new VoicevoxError(
+            `APIリクエストに失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+            VoicevoxErrorCode.API_CONNECTION_ERROR
+          )
+        }
+        lastError = error
       }
-      if (responseType === 'text') {
-        return (await response.text()) as T
-      }
-      if (response.status === 204) {
-        return null as T
-      }
-      return (await response.json()) as T
-    } catch (error) {
-      if (error instanceof VoicevoxError) {
-        throw error
-      }
-      throw new VoicevoxError(
-        `APIリクエストに失敗しました: ${error instanceof Error ? error.message : String(error)}`,
-        VoicevoxErrorCode.API_CONNECTION_ERROR
-      )
     }
+
+    // ここには到達しないが TypeScript のために
+    throw new VoicevoxError(
+      `APIリクエストに失敗しました: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+      VoicevoxErrorCode.API_CONNECTION_ERROR
+    )
   }
 
   /**

--- a/packages/voicevox-client/src/client.ts
+++ b/packages/voicevox-client/src/client.ts
@@ -84,7 +84,11 @@ export class VoicevoxClient {
       this.defaultPlaybackOptions.waitForEnd = envOptions.waitForEnd
     }
 
-    this.api = new VoicevoxApi(config.url)
+    this.api = new VoicevoxApi(config.url, {
+      timeout: config.apiTimeout,
+      retryCount: config.apiRetryCount,
+      retryDelay: config.apiRetryDelay,
+    })
     this.queueService = new QueueService(this.api, {
       useStreaming: config.useStreaming,
       prefetchSize: config.prefetchSize,

--- a/packages/voicevox-client/src/types.ts
+++ b/packages/voicevox-client/src/types.ts
@@ -20,6 +20,12 @@ export interface VoicevoxConfig {
   maxSegmentLength?: number
   /** 先読みする音声の最大件数（READY + GENERATING の上限、デフォルト: 2） */
   prefetchSize?: number
+  /** APIリクエストのタイムアウト（ミリ秒、デフォルト: 30000） */
+  apiTimeout?: number
+  /** 一時的なAPIエラー（タイムアウト・ネットワーク障害）時のリトライ回数（デフォルト: 0） */
+  apiRetryCount?: number
+  /** リトライ間隔（ミリ秒、デフォルト: 1000） */
+  apiRetryDelay?: number
   /** デフォルトの再生オプション */
   defaultPlaybackOptions?: PlaybackOptions
   /**


### PR DESCRIPTION
Add apiTimeout, apiRetryCount, and apiRetryDelay options to VoicevoxConfig
and VoicevoxApi. Retries are limited to transient failures (timeout and
network errors); HTTP error responses are not retried.

Defaults match existing behavior: 30s timeout, 0 retries.

Exposed via CLI flags and env vars:
  --api-timeout / VOICEVOX_API_TIMEOUT
  --api-retry-count / VOICEVOX_API_RETRY_COUNT
  --api-retry-delay / VOICEVOX_API_RETRY_DELAY

https://claude.ai/code/session_018WX6jKUiBkUpCdQcrVjTM1