### PR TITLE
fix: avoid guiding users toward disabled tools

### DIFF
--- a/apps/mcp-tts/src/tools/__tests__/tool-hints.test.ts
+++ b/apps/mcp-tts/src/tools/__tests__/tool-hints.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerGetPlayerStateTool } from '../player/get-player-state-tool.js'
+import { registerSpeakTool } from '../speak.js'
+import { registerSpeakerTools } from '../speakers.js'
+import { buildNextHint, composeDescription, enabledToolRef, isToolEnabled } from '../tool-hints.js'
+import type { ToolDeps } from '../types.js'
+
+describe('tool-hints helpers', () => {
+  describe('isToolEnabled / enabledToolRef', () => {
+    it('returns the prefixed name when the tool is enabled', () => {
+      const disabled = new Set<string>()
+      expect(isToolEnabled(disabled, 'speak')).toBe(true)
+      expect(enabledToolRef(disabled, 'speak')).toBe('voicevox_speak')
+    })
+
+    it('returns undefined when the tool is disabled (unprefixed name)', () => {
+      const disabled = new Set(['speak_player'])
+      expect(isToolEnabled(disabled, 'speak_player')).toBe(false)
+      expect(enabledToolRef(disabled, 'speak_player')).toBeUndefined()
+    })
+
+    it('also matches the prefixed name in the disabled set', () => {
+      const disabled = new Set(['voicevox_speak_player'])
+      expect(enabledToolRef(disabled, 'speak_player')).toBeUndefined()
+    })
+  })
+
+  describe('composeDescription', () => {
+    it('drops falsy parts and joins with a single space', () => {
+      expect(composeDescription('A.', false, undefined, 'B.')).toBe('A. B.')
+    })
+  })
+
+  describe('buildNextHint', () => {
+    it('includes only enabled tools', () => {
+      const disabled = new Set(['get_player_state'])
+      const hint = buildNextHint(disabled, [
+        { name: 'resynthesize_player', label: 'edit a track' },
+        { name: 'get_player_state', label: 'inspect state' },
+      ])
+      expect(hint).toBe('Next: voicevox_resynthesize_player (edit a track)')
+      expect(hint).not.toContain('get_player_state')
+    })
+
+    it('returns an empty string when every step is disabled', () => {
+      const disabled = new Set(['resynthesize_player', 'get_player_state'])
+      const hint = buildNextHint(disabled, [
+        { name: 'resynthesize_player', label: 'edit a track' },
+        { name: 'get_player_state', label: 'inspect state' },
+      ])
+      expect(hint).toBe('')
+    })
+  })
+})
+
+const mockRegisterTool = vi.fn()
+
+function createMockDeps(disabledTools: Set<string>): ToolDeps {
+  return {
+    server: { registerTool: mockRegisterTool } as any,
+    voicevoxClient: {} as any,
+    config: { defaultSpeaker: 1, defaultSpeedScale: 1.0 } as any,
+    disabledTools,
+    restrictions: { immediate: false, waitForStart: false, waitForEnd: false },
+  }
+}
+
+function getDescription(toolName: string): string {
+  const call = mockRegisterTool.mock.calls.find((c: any[]) => c[0] === toolName)
+  expect(call).toBeDefined()
+  return call![1].description as string
+}
+
+describe('disabled-tool guidance in descriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('speak description omits the player reference when the player group is disabled', () => {
+    registerSpeakTool(createMockDeps(new Set(['speak_player'])))
+    expect(getDescription('voicevox_speak')).not.toContain('speak_player')
+  })
+
+  it('speak description guides to the player when it is enabled', () => {
+    registerSpeakTool(createMockDeps(new Set<string>()))
+    expect(getDescription('voicevox_speak')).toContain('voicevox_speak_player')
+  })
+
+  it('get_speakers description omits the speak reference when speak is disabled', () => {
+    registerSpeakerTools(createMockDeps(new Set(['speak'])))
+    const desc = getDescription('voicevox_get_speakers')
+    expect(desc).not.toContain('voicevox_speak')
+    expect(desc).toContain('speaker parameter')
+  })
+
+  it('get_player_state description omits player tools disabled via the apps group', () => {
+    registerGetPlayerStateTool(createMockDeps(new Set(['speak_player', 'resynthesize_player'])), {} as any)
+    const desc = getDescription('voicevox_get_player_state')
+    expect(desc).not.toContain('speak_player')
+    expect(desc).not.toContain('resynthesize_player')
+  })
+})

--- a/apps/mcp-tts/src/tools/player/get-player-state-tool.ts
+++ b/apps/mcp-tts/src/tools/player/get-player-state-tool.ts
@@ -2,6 +2,7 @@ import { type AccentPhrase, accentPhrasesToNotation } from '@kajidog/voicevox-cl
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
 import { registerToolIfEnabled } from '../registration.js'
+import { composeDescription, enabledToolRef } from '../tool-hints.js'
 import type { ToolDeps, ToolHandlerExtra } from '../types.js'
 import { createErrorResponse } from '../utils.js'
 import type { PlayerRuntime } from './runtime.js'
@@ -10,19 +11,40 @@ import { DEFAULT_STATE_PAGE_LIMIT, MAX_STATE_PAGE_LIMIT, MAX_TOOL_CONTENT_BYTES 
 export function registerGetPlayerStateTool(deps: ToolDeps, runtime: PlayerRuntime): void {
   const { server, disabledTools } = deps
 
+  // viewUUID を払い出す有効なツールだけを参照する。
+  const sourceRefs = [
+    enabledToolRef(disabledTools, 'speak_player'),
+    enabledToolRef(disabledTools, 'resynthesize_player'),
+  ].filter((r): r is string => Boolean(r))
+  const sourceList = sourceRefs.join('/')
+
+  // 「トラック編集」案内は resynthesize_player が有効なときだけ出す。
+  const resynthesizeRef = enabledToolRef(disabledTools, 'resynthesize_player')
+  const editHint = resynthesizeRef
+    ? `To edit a track, call ${resynthesizeRef} with viewUUID + trackIndex. The "phrases" param uses inline notation: comma-separated phrases, [bracket] marks accent mora. Example: "コン[ニ]チワ,セ[カ]イ". Omit brackets to use VOICEVOX default accent. Omitted params keep existing values.`
+    : undefined
+
   registerToolIfEnabled(
     server,
     disabledTools,
     'get_player_state',
     {
       title: 'Get VOICEVOX Player State',
-      description:
-        'Read current player state (segments, accent phrases). Use latest viewUUID from speak_player/resynthesize_player. If hasMore is true, call again with nextCursor.',
+      description: composeDescription(
+        'Read current player state (segments, accent phrases).',
+        sourceList && `Use latest viewUUID from ${sourceList}.`,
+        'If hasMore is true, call again with nextCursor.'
+      ),
       inputSchema: {
         viewUUID: z
           .string()
           .optional()
-          .describe('Player instance ID from speak_player/resynthesize_player. Always pass the latest viewUUID.'),
+          .describe(
+            composeDescription(
+              sourceList ? `Player instance ID from ${sourceList}.` : 'Player instance ID.',
+              'Always pass the latest viewUUID.'
+            )
+          ),
         cursor: z.number().int().min(0).optional().describe('Start index in segments array (default: 0)'),
         limit: z
           .number()
@@ -102,11 +124,7 @@ export function registerGetPlayerStateTool(deps: ToolDeps, runtime: PlayerRuntim
             limit: effectiveLimit,
             hasMore,
             nextCursor: hasMore ? pageEnd : null,
-            ...(effectiveCursor === 0 && responseSegments.length > 0
-              ? {
-                  hint: 'To edit a track, call resynthesize_player with viewUUID + trackIndex. The "phrases" param uses inline notation: comma-separated phrases, [bracket] marks accent mora. Example: "コン[ニ]チワ,セ[カ]イ". Omit brackets to use VOICEVOX default accent. Omitted params keep existing values.',
-                }
-              : {}),
+            ...(effectiveCursor === 0 && responseSegments.length > 0 && editHint ? { hint: editHint } : {}),
           }
         }
 

--- a/apps/mcp-tts/src/tools/player/resynthesize-player-tool.ts
+++ b/apps/mcp-tts/src/tools/player/resynthesize-player-tool.ts
@@ -3,6 +3,7 @@ import { type AccentPhrase, type AudioQuery, applyNotationAccents, parseNotation
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
 import { registerAppToolIfEnabled } from '../registration.js'
+import { composeDescription, enabledToolRef } from '../tool-hints.js'
 import type { ToolDeps, ToolHandlerExtra } from '../types.js'
 import { createErrorResponse, getEffectiveSpeaker } from '../utils.js'
 import type { PlayerRuntime } from './runtime.js'
@@ -12,18 +13,31 @@ import type { PlayerSegmentState } from './session-state.js'
 export function registerResynthesizePlayerTool(deps: ToolDeps, runtime: PlayerRuntime): void {
   const { server, config, disabledTools } = deps
 
+  // viewUUID を払い出す有効なツールだけを列挙する（自分自身は常に有効）。
+  const sourceRefs = [
+    enabledToolRef(disabledTools, 'speak_player'),
+    enabledToolRef(disabledTools, 'resynthesize_player'),
+  ].filter((r): r is string => Boolean(r))
+  const stateHintRef = enabledToolRef(disabledTools, 'get_player_state')
+
   registerAppToolIfEnabled(
     server,
     disabledTools,
     'resynthesize_player',
     {
       title: 'Resynthesize Player',
-      description:
-        'Edit one player track by index. Requires viewUUID from speak_player/resynthesize_player. Returns new viewUUID.',
+      description: composeDescription(
+        'Edit one player track by index.',
+        sourceRefs.length > 0 && `Requires viewUUID from ${sourceRefs.join('/')}.`,
+        'Returns new viewUUID.'
+      ),
       inputSchema: {
         viewUUID: z.string().describe('Latest viewUUID'),
         trackIndex: z.number().int().min(0).describe('Segment index to update'),
-        phrases: z.string().optional().describe('Inline notation (see get_player_state hint)'),
+        phrases: z
+          .string()
+          .optional()
+          .describe(stateHintRef ? `Inline notation (see ${stateHintRef} hint)` : 'Inline notation'),
         speaker: z.number().optional().describe('Speaker ID'),
         speedScale: z.number().optional().describe('Speed'),
         intonationScale: z.number().optional().describe('Intonation'),
@@ -72,7 +86,13 @@ export function registerResynthesizePlayerTool(deps: ToolDeps, runtime: PlayerRu
       try {
         const state = runtime.getSessionState(inputViewUUID, extra?.sessionId)
         if (!state) {
-          throw new Error('No player state found for the given viewUUID. Use speak_player first.')
+          const speakPlayerRef = enabledToolRef(disabledTools, 'speak_player')
+          throw new Error(
+            composeDescription(
+              'No player state found for the given viewUUID.',
+              speakPlayerRef && `Use ${speakPlayerRef} first.`
+            )
+          )
         }
         if (trackIndex < 0 || trackIndex >= state.segments.length) {
           throw new Error(`trackIndex ${trackIndex} is out of range. Valid range: 0-${state.segments.length - 1}`)

--- a/apps/mcp-tts/src/tools/player/speak-player-tool.ts
+++ b/apps/mcp-tts/src/tools/player/speak-player-tool.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
 import { registerAppToolIfEnabled } from '../registration.js'
+import { buildNextHint, composeDescription, enabledToolRef } from '../tool-hints.js'
 import type { ToolDeps, ToolHandlerExtra } from '../types.js'
 import { createErrorResponse, getEffectiveSpeaker, parseStringInput } from '../utils.js'
 import type { PlayerRuntime } from './runtime.js'
@@ -10,14 +11,18 @@ import { playerResourceUri } from './runtime.js'
 export function registerSpeakPlayerTool(deps: ToolDeps, runtime: PlayerRuntime): void {
   const { server, config, disabledTools } = deps
 
+  const speakRef = enabledToolRef(disabledTools, 'speak')
+
   registerAppToolIfEnabled(
     server,
     disabledTools,
     'speak_player',
     {
       title: 'Speak Player',
-      description:
-        'Use when you need a player UI (display, edit, or replay audio). Creates a VOICEVOX player session, returns viewUUID. Multi-speaker format: "1:Hello\\n2:World". For simple playback without UI, use voicevox_speak instead.',
+      description: composeDescription(
+        'Use when you need a player UI (display, edit, or replay audio). Creates a VOICEVOX player session, returns viewUUID. Multi-speaker format: "1:Hello\\n2:World".',
+        speakRef && `For simple playback without UI, use ${speakRef} instead.`
+      ),
       inputSchema: {
         text: z
           .string()
@@ -88,11 +93,15 @@ export function registerSpeakPlayerTool(deps: ToolDeps, runtime: PlayerRuntime):
           speakerName: speakerNameMap.get(s.speaker),
           speedScale: s.speedScale,
         }))
+        const nextHint = buildNextHint(disabledTools, [
+          { name: 'resynthesize_player', label: 'edit a track' },
+          { name: 'get_player_state', label: 'inspect state' },
+        ])
         return {
           content: [
             {
               type: 'text',
-              text: `Voicevox Player started. viewUUID: ${viewUUID} 「${textPreview}」\nNext: voicevox_resynthesize_player (edit a track) | voicevox_get_player_state (inspect state)`,
+              text: `Voicevox Player started. viewUUID: ${viewUUID} 「${textPreview}」${nextHint ? `\n${nextHint}` : ''}`,
             },
           ],
           structuredContent: {

--- a/apps/mcp-tts/src/tools/registration.ts
+++ b/apps/mcp-tts/src/tools/registration.ts
@@ -21,7 +21,7 @@ export function addToolPrefix(name: string): string {
 /**
  * Check if a tool is disabled, accepting both prefixed and unprefixed names.
  */
-function isToolDisabled(disabledTools: Set<string>, name: string): boolean {
+export function isToolDisabled(disabledTools: Set<string>, name: string): boolean {
   const fullName = addToolPrefix(name)
   return disabledTools.has(name) || disabledTools.has(fullName)
 }

--- a/apps/mcp-tts/src/tools/speak.ts
+++ b/apps/mcp-tts/src/tools/speak.ts
@@ -3,6 +3,7 @@ import { applyNotationAccents, parseNotation, type SpeakResult, VoicevoxApi } fr
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
 import { registerToolIfEnabled } from './registration.js'
+import { composeDescription, enabledToolRef } from './tool-hints.js'
 import type { ToolDeps, ToolHandlerExtra } from './types.js'
 import {
   createErrorResponse,
@@ -59,14 +60,18 @@ export function buildSpeakInputSchema(restrictions: {
 export function registerSpeakTool(deps: ToolDeps) {
   const { server, voicevoxClient, config, disabledTools, restrictions } = deps
 
+  const playerRef = enabledToolRef(disabledTools, 'speak_player')
+
   registerToolIfEnabled(
     server,
     disabledTools,
     'speak',
     {
       title: 'Speak',
-      description:
-        'Play text as speech immediately. Use this for simple TTS — no UI, no editing. If you need a player UI or want to edit/replay segments, use voicevox_speak_player instead.',
+      description: composeDescription(
+        'Play text as speech immediately. Use this for simple TTS — no UI, no editing.',
+        playerRef && `If you need a player UI or want to edit/replay segments, use ${playerRef} instead.`
+      ),
       inputSchema: buildSpeakInputSchema(restrictions),
       annotations: {
         readOnlyHint: false,

--- a/apps/mcp-tts/src/tools/speakers.ts
+++ b/apps/mcp-tts/src/tools/speakers.ts
@@ -1,10 +1,13 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { registerToolIfEnabled } from './registration.js'
+import { composeDescription, enabledToolRef } from './tool-hints.js'
 import type { ToolDeps } from './types.js'
 import { createErrorResponse, createSuccessResponse } from './utils.js'
 
 export function registerSpeakerTools(deps: ToolDeps) {
   const { server, voicevoxClient, disabledTools } = deps
+
+  const speakRef = enabledToolRef(disabledTools, 'speak')
 
   // ping_voicevox ツール
   registerToolIfEnabled(
@@ -68,8 +71,12 @@ export function registerSpeakerTools(deps: ToolDeps) {
     'get_speakers',
     {
       title: 'Get Speakers',
-      description:
-        'Get a list of available speakers. The returned "speaker" field is the exact ID to pass to speak.speaker',
+      description: composeDescription(
+        'Get a list of available speakers.',
+        speakRef
+          ? `The returned "speaker" field is the exact ID to pass to ${speakRef}.speaker.`
+          : 'The returned "speaker" field is the exact ID to pass as the speaker parameter.'
+      ),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/apps/mcp-tts/src/tools/tool-hints.ts
+++ b/apps/mcp-tts/src/tools/tool-hints.ts
@@ -1,0 +1,51 @@
+/**
+ * Helpers for referencing OTHER tools from a tool's description, output text, or
+ * error messages WITHOUT pointing users at a tool that is currently disabled.
+ *
+ * When tools are turned off via `--disable-tools` / `--disable-groups`, any
+ * hard-coded "use voicevox_x instead" guidance becomes misleading. Routing every
+ * cross-tool reference through these helpers makes it structurally impossible to
+ * mention a disabled tool — the reference simply drops out.
+ */
+import { addToolPrefix, isToolDisabled } from './registration.js'
+
+/**
+ * True when a tool is enabled (i.e. not disabled). Accepts both prefixed and
+ * unprefixed names.
+ */
+export function isToolEnabled(disabledTools: Set<string>, name: string): boolean {
+  return !isToolDisabled(disabledTools, name)
+}
+
+/**
+ * Return the full prefixed tool name (e.g. `voicevox_speak`) when the tool is
+ * enabled, otherwise `undefined`. Use the result in a truthy check so disabled
+ * tools naturally drop out of any guidance string.
+ */
+export function enabledToolRef(disabledTools: Set<string>, name: string): string | undefined {
+  return isToolEnabled(disabledTools, name) ? addToolPrefix(name) : undefined
+}
+
+/**
+ * Join sentence fragments into a single description, dropping any falsy parts.
+ * Lets callers append conditional clauses (e.g. an `enabledToolRef && '...'`
+ * expression) without worrying about stray spaces.
+ */
+export function composeDescription(...parts: Array<string | undefined | false>): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ')
+}
+
+/**
+ * Build a "Next: a (label) | b (label)" hint from only the enabled tools.
+ * Returns an empty string when none of the steps are enabled.
+ */
+export function buildNextHint(
+  disabledTools: Set<string>,
+  steps: Array<{ name: string; label: string }>,
+  prefix = 'Next: '
+): string {
+  const parts = steps
+    .filter((s) => isToolEnabled(disabledTools, s.name))
+    .map((s) => `${addToolPrefix(s.name)} (${s.label})`)
+  return parts.length > 0 ? `${prefix}${parts.join(' | ')}` : ''
+}


### PR DESCRIPTION
Tool descriptions, output text, and error messages hard-coded references to
other tools (e.g. speak → speak_player). When those tools were turned off via
--disable-tools / --disable-groups, the guidance pointed at tools that no
longer exist.

Route every cross-tool reference through new tool-hints helpers
(enabledToolRef / composeDescription / buildNextHint) so a disabled tool is
structurally dropped from the text instead of being mentioned.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E78wHVnkXhcorszYcMJa7J