### PR TITLE
fix: avoid guiding LLMs to disabled tools in descriptions and responses

### DIFF
--- a/apps/mcp-tts/src/__tests__/tool-disabling.test.ts
+++ b/apps/mcp-tts/src/__tests__/tool-disabling.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getConfig, resetConfigCache } from '../config'
 import { expandGroups, TOOL_GROUPS } from '../tool-groups'
+import { registerGetPlayerStateTool } from '../tools/player/get-player-state-tool'
+import { registerResynthesizePlayerTool } from '../tools/player/resynthesize-player-tool'
+import type { PlayerRuntime } from '../tools/player/runtime'
+import { registerSpeakPlayerTool } from '../tools/player/speak-player-tool'
+import { registerSpeakTool } from '../tools/speak'
+import { registerSpeakerTools } from '../tools/speakers'
+import type { ToolDeps } from '../tools/types'
 
 describe('tool disabling', () => {
   const originalEnv = process.env
@@ -168,6 +175,166 @@ describe('tool groups (--disable-groups)', () => {
       const config = getConfig([], {})
 
       expect(config.disabledGroups).toEqual([])
+    })
+  })
+})
+
+describe('disabled-tool guidance in descriptions and responses', () => {
+  function createDeps(disabledTools: Iterable<string> = []) {
+    const registerTool = vi.fn()
+    const deps: ToolDeps = {
+      server: { registerTool } as any,
+      voicevoxClient: {} as any,
+      config: {
+        voicevoxUrl: 'http://localhost:50021',
+        defaultSpeaker: 1,
+        defaultSpeedScale: 1,
+        defaultImmediate: true,
+        defaultWaitForStart: false,
+        defaultWaitForEnd: false,
+        autoPlay: true,
+      } as any,
+      disabledTools: new Set(disabledTools),
+      restrictions: { immediate: false, waitForStart: false, waitForEnd: false },
+    }
+    const getRegisteredCall = (name: string) => {
+      const call = registerTool.mock.calls.find((c: any[]) => c[0] === name)
+      expect(call).toBeDefined()
+      return call!
+    }
+    return {
+      deps,
+      getToolConfig: (name: string) => getRegisteredCall(name)[1],
+      getToolHandler: (name: string) => getRegisteredCall(name)[2],
+    }
+  }
+
+  function createMockRuntime(overrides: Partial<PlayerRuntime> = {}): PlayerRuntime {
+    return {
+      playerVoicevoxApi: {} as any,
+      getSpeakerList: vi.fn(async () => []),
+      getSpeakerName: vi.fn(async (id: number) => `Speaker ${id}`),
+      resolveSpeakerNames: vi.fn(async (ids: number[]) => new Map(ids.map((id) => [id, `Speaker ${id}`]))),
+      getUserDictionaryWords: vi.fn(async () => []),
+      synthesizeWithCache: vi.fn(),
+      setSessionState: vi.fn(),
+      getSessionState: vi.fn(() => undefined),
+      getSessionStateByKey: vi.fn(() => undefined),
+      ...overrides,
+    }
+  }
+
+  describe('無効化なし（回帰確認）', () => {
+    it('speak の description は voicevox_speak_player を案内する', () => {
+      const { deps, getToolConfig } = createDeps()
+      registerSpeakTool(deps)
+      expect(getToolConfig('voicevox_speak').description).toContain('voicevox_speak_player')
+    })
+
+    it('get_player_state の description と viewUUID は speak_player/resynthesize_player を案内する', () => {
+      const { deps, getToolConfig } = createDeps()
+      registerGetPlayerStateTool(deps, createMockRuntime())
+      const config = getToolConfig('voicevox_get_player_state')
+      expect(config.description).toContain('speak_player/resynthesize_player')
+      expect(config.inputSchema.viewUUID.description).toContain('speak_player/resynthesize_player')
+    })
+
+    it('speak_player の description は voicevox_speak を案内する', () => {
+      const { deps, getToolConfig } = createDeps()
+      registerSpeakPlayerTool(deps, createMockRuntime())
+      expect(getToolConfig('voicevox_speak_player').description).toContain('voicevox_speak')
+    })
+
+    it('get_speakers の description は speak.speaker を案内する', () => {
+      const { deps, getToolConfig } = createDeps()
+      registerSpeakerTools(deps)
+      expect(getToolConfig('voicevox_get_speakers').description).toContain('speak.speaker')
+    })
+  })
+
+  describe('--disable-groups apps 相当（speak_player/resynthesize_player が無効）', () => {
+    const appsDisabled = expandGroups(['apps'])
+
+    it('speak の description に speak_player が現れない', () => {
+      const { deps, getToolConfig } = createDeps(appsDisabled)
+      registerSpeakTool(deps)
+      expect(getToolConfig('voicevox_speak').description).not.toContain('speak_player')
+    })
+
+    it('get_player_state の description と viewUUID に無効ツール名が現れない', () => {
+      const { deps, getToolConfig } = createDeps(appsDisabled)
+      registerGetPlayerStateTool(deps, createMockRuntime())
+      const config = getToolConfig('voicevox_get_player_state')
+      expect(config.description).not.toContain('speak_player')
+      expect(config.description).not.toContain('resynthesize_player')
+      expect(config.inputSchema.viewUUID.description).not.toContain('speak_player')
+      expect(config.inputSchema.viewUUID.description).not.toContain('resynthesize_player')
+    })
+
+    it('get_player_state のレスポンス hint が resynthesize_player 無効時に省略される', async () => {
+      const state = { segments: [{ text: 'こんにちは', speaker: 1 }], updatedAt: 1 }
+      const { deps, getToolHandler } = createDeps(appsDisabled)
+      registerGetPlayerStateTool(deps, createMockRuntime({ getSessionState: vi.fn(() => state) }))
+      const result = await getToolHandler('voicevox_get_player_state')({}, {})
+      const payload = JSON.parse(result.content[0].text)
+      expect(payload.hint).toBeUndefined()
+    })
+
+    it('get_player_state のレスポンス hint は有効時には含まれる', async () => {
+      const state = { segments: [{ text: 'こんにちは', speaker: 1 }], updatedAt: 1 }
+      const { deps, getToolHandler } = createDeps()
+      registerGetPlayerStateTool(deps, createMockRuntime({ getSessionState: vi.fn(() => state) }))
+      const result = await getToolHandler('voicevox_get_player_state')({}, {})
+      const payload = JSON.parse(result.content[0].text)
+      expect(payload.hint).toContain('resynthesize_player')
+    })
+  })
+
+  describe('個別無効化', () => {
+    it('speak 無効時、speak_player の description に voicevox_speak が現れない', () => {
+      const { deps, getToolConfig } = createDeps(['speak'])
+      registerSpeakPlayerTool(deps, createMockRuntime())
+      const description = getToolConfig('voicevox_speak_player').description
+      // 自ツール名 (voicevox_speak_player) は含まれてよいが、voicevox_speak 単体への案内は消える
+      expect(description).not.toContain('use voicevox_speak instead')
+    })
+
+    it('speak 無効時、get_speakers の description に speak.speaker が現れない', () => {
+      const { deps, getToolConfig } = createDeps(['speak'])
+      registerSpeakerTools(deps)
+      expect(getToolConfig('voicevox_get_speakers').description).not.toContain('speak.speaker')
+    })
+
+    it('speak_player の Next 行は無効ツールを列挙しない', async () => {
+      const { deps, getToolHandler } = createDeps(['get_player_state'])
+      registerSpeakPlayerTool(deps, createMockRuntime())
+      const result = await getToolHandler('voicevox_speak_player')({ text: 'こんにちは' }, {})
+      const text = result.content[0].text
+      expect(text).toContain('voicevox_resynthesize_player')
+      expect(text).not.toContain('voicevox_get_player_state')
+    })
+
+    it('speak_player の Next 行は後続ツールが全て無効なら省略される', async () => {
+      const { deps, getToolHandler } = createDeps(['get_player_state', 'resynthesize_player'])
+      registerSpeakPlayerTool(deps, createMockRuntime())
+      const result = await getToolHandler('voicevox_speak_player')({ text: 'こんにちは' }, {})
+      expect(result.content[0].text).not.toContain('Next:')
+    })
+
+    it('resynthesize_player のエラー文は speak_player 無効時に案内を含まない', async () => {
+      const { deps, getToolHandler } = createDeps(['speak_player'])
+      registerResynthesizePlayerTool(deps, createMockRuntime())
+      const result = await getToolHandler('voicevox_resynthesize_player')({ viewUUID: 'x', trackIndex: 0 }, {})
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).not.toContain('speak_player')
+    })
+
+    it('resynthesize_player のエラー文は speak_player 有効時に案内を含む', async () => {
+      const { deps, getToolHandler } = createDeps()
+      registerResynthesizePlayerTool(deps, createMockRuntime())
+      const result = await getToolHandler('voicevox_resynthesize_player')({ viewUUID: 'x', trackIndex: 0 }, {})
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Use speak_player first')
     })
   })
 })

--- a/apps/mcp-tts/src/tools/player/get-player-state-tool.ts
+++ b/apps/mcp-tts/src/tools/player/get-player-state-tool.ts
@@ -1,7 +1,7 @@
 import { type AccentPhrase, accentPhrasesToNotation } from '@kajidog/voicevox-client'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
-import { registerToolIfEnabled } from '../registration.js'
+import { isToolEnabled, registerToolIfEnabled } from '../registration.js'
 import type { ToolDeps, ToolHandlerExtra } from '../types.js'
 import { createErrorResponse } from '../utils.js'
 import type { PlayerRuntime } from './runtime.js'
@@ -10,19 +10,21 @@ import { DEFAULT_STATE_PAGE_LIMIT, MAX_STATE_PAGE_LIMIT, MAX_TOOL_CONTENT_BYTES 
 export function registerGetPlayerStateTool(deps: ToolDeps, runtime: PlayerRuntime): void {
   const { server, disabledTools } = deps
 
+  const viewUUIDSources = ['speak_player', 'resynthesize_player'].filter((name) => isToolEnabled(disabledTools, name))
+  const viewUUIDOrigin = viewUUIDSources.length > 0 ? viewUUIDSources.join('/') : 'the player session'
+
   registerToolIfEnabled(
     server,
     disabledTools,
     'get_player_state',
     {
       title: 'Get VOICEVOX Player State',
-      description:
-        'Read current player state (segments, accent phrases). Use latest viewUUID from speak_player/resynthesize_player. If hasMore is true, call again with nextCursor.',
+      description: `Read current player state (segments, accent phrases). Use latest viewUUID from ${viewUUIDOrigin}. If hasMore is true, call again with nextCursor.`,
       inputSchema: {
         viewUUID: z
           .string()
           .optional()
-          .describe('Player instance ID from speak_player/resynthesize_player. Always pass the latest viewUUID.'),
+          .describe(`Player instance ID from ${viewUUIDOrigin}. Always pass the latest viewUUID.`),
         cursor: z.number().int().min(0).optional().describe('Start index in segments array (default: 0)'),
         limit: z
           .number()
@@ -102,7 +104,10 @@ export function registerGetPlayerStateTool(deps: ToolDeps, runtime: PlayerRuntim
             limit: effectiveLimit,
             hasMore,
             nextCursor: hasMore ? pageEnd : null,
-            ...(effectiveCursor === 0 && responseSegments.length > 0
+            // hint は resynthesize_player 専用の案内のため、無効時は付与しない。
+            ...(effectiveCursor === 0 &&
+            responseSegments.length > 0 &&
+            isToolEnabled(disabledTools, 'resynthesize_player')
               ? {
                   hint: 'To edit a track, call resynthesize_player with viewUUID + trackIndex. The "phrases" param uses inline notation: comma-separated phrases, [bracket] marks accent mora. Example: "コン[ニ]チワ,セ[カ]イ". Omit brackets to use VOICEVOX default accent. Omitted params keep existing values.',
                 }

--- a/apps/mcp-tts/src/tools/player/resynthesize-player-tool.ts
+++ b/apps/mcp-tts/src/tools/player/resynthesize-player-tool.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { type AccentPhrase, type AudioQuery, applyNotationAccents, parseNotation } from '@kajidog/voicevox-client'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
-import { registerAppToolIfEnabled } from '../registration.js'
+import { isToolEnabled, registerAppToolIfEnabled } from '../registration.js'
 import type { ToolDeps, ToolHandlerExtra } from '../types.js'
 import { createErrorResponse, getEffectiveSpeaker } from '../utils.js'
 import type { PlayerRuntime } from './runtime.js'
@@ -12,18 +12,24 @@ import type { PlayerSegmentState } from './session-state.js'
 export function registerResynthesizePlayerTool(deps: ToolDeps, runtime: PlayerRuntime): void {
   const { server, config, disabledTools } = deps
 
+  const viewUUIDOrigin = isToolEnabled(disabledTools, 'speak_player')
+    ? 'speak_player/resynthesize_player'
+    : 'a previous resynthesize_player call'
+  const phrasesDescription = isToolEnabled(disabledTools, 'get_player_state')
+    ? 'Inline notation (see get_player_state hint)'
+    : 'Inline notation: comma-separated phrases, [bracket] marks accent mora. Example: "コン[ニ]チワ,セ[カ]イ"'
+
   registerAppToolIfEnabled(
     server,
     disabledTools,
     'resynthesize_player',
     {
       title: 'Resynthesize Player',
-      description:
-        'Edit one player track by index. Requires viewUUID from speak_player/resynthesize_player. Returns new viewUUID.',
+      description: `Edit one player track by index. Requires viewUUID from ${viewUUIDOrigin}. Returns new viewUUID.`,
       inputSchema: {
         viewUUID: z.string().describe('Latest viewUUID'),
         trackIndex: z.number().int().min(0).describe('Segment index to update'),
-        phrases: z.string().optional().describe('Inline notation (see get_player_state hint)'),
+        phrases: z.string().optional().describe(phrasesDescription),
         speaker: z.number().optional().describe('Speaker ID'),
         speedScale: z.number().optional().describe('Speed'),
         intonationScale: z.number().optional().describe('Intonation'),
@@ -72,7 +78,11 @@ export function registerResynthesizePlayerTool(deps: ToolDeps, runtime: PlayerRu
       try {
         const state = runtime.getSessionState(inputViewUUID, extra?.sessionId)
         if (!state) {
-          throw new Error('No player state found for the given viewUUID. Use speak_player first.')
+          throw new Error(
+            isToolEnabled(disabledTools, 'speak_player')
+              ? 'No player state found for the given viewUUID. Use speak_player first.'
+              : 'No player state found for the given viewUUID.'
+          )
         }
         if (trackIndex < 0 || trackIndex >= state.segments.length) {
           throw new Error(`trackIndex ${trackIndex} is out of range. Valid range: 0-${state.segments.length - 1}`)

--- a/apps/mcp-tts/src/tools/player/speak-player-tool.ts
+++ b/apps/mcp-tts/src/tools/player/speak-player-tool.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
-import { registerAppToolIfEnabled } from '../registration.js'
+import { isToolEnabled, registerAppToolIfEnabled } from '../registration.js'
 import type { ToolDeps, ToolHandlerExtra } from '../types.js'
 import { createErrorResponse, getEffectiveSpeaker, parseStringInput } from '../utils.js'
 import type { PlayerRuntime } from './runtime.js'
@@ -17,7 +17,8 @@ export function registerSpeakPlayerTool(deps: ToolDeps, runtime: PlayerRuntime):
     {
       title: 'Speak Player',
       description:
-        'Use when you need a player UI (display, edit, or replay audio). Creates a VOICEVOX player session, returns viewUUID. Multi-speaker format: "1:Hello\\n2:World". For simple playback without UI, use voicevox_speak instead.',
+        'Use when you need a player UI (display, edit, or replay audio). Creates a VOICEVOX player session, returns viewUUID. Multi-speaker format: "1:Hello\\n2:World".' +
+        (isToolEnabled(disabledTools, 'speak') ? ' For simple playback without UI, use voicevox_speak instead.' : ''),
       inputSchema: {
         text: z
           .string()
@@ -88,11 +89,19 @@ export function registerSpeakPlayerTool(deps: ToolDeps, runtime: PlayerRuntime):
           speakerName: speakerNameMap.get(s.speaker),
           speedScale: s.speedScale,
         }))
+        const nextSteps = [
+          ...(isToolEnabled(disabledTools, 'resynthesize_player')
+            ? ['voicevox_resynthesize_player (edit a track)']
+            : []),
+          ...(isToolEnabled(disabledTools, 'get_player_state') ? ['voicevox_get_player_state (inspect state)'] : []),
+        ]
         return {
           content: [
             {
               type: 'text',
-              text: `Voicevox Player started. viewUUID: ${viewUUID} 「${textPreview}」\nNext: voicevox_resynthesize_player (edit a track) | voicevox_get_player_state (inspect state)`,
+              text:
+                `Voicevox Player started. viewUUID: ${viewUUID} 「${textPreview}」` +
+                (nextSteps.length > 0 ? `\nNext: ${nextSteps.join(' | ')}` : ''),
             },
           ],
           structuredContent: {

--- a/apps/mcp-tts/src/tools/registration.ts
+++ b/apps/mcp-tts/src/tools/registration.ts
@@ -27,6 +27,14 @@ function isToolDisabled(disabledTools: Set<string>, name: string): boolean {
 }
 
 /**
+ * Check if a tool will be registered (not disabled).
+ * Use this to avoid mentioning disabled tools in descriptions/responses.
+ */
+export function isToolEnabled(disabledTools: Set<string>, name: string): boolean {
+  return !isToolDisabled(disabledTools, name)
+}
+
+/**
  * Register a tool with auto-prefixed name (disabled tools are skipped).
  *
  * Uses rest args to forward all overload variants of `McpServer.registerTool`

--- a/apps/mcp-tts/src/tools/speak.ts
+++ b/apps/mcp-tts/src/tools/speak.ts
@@ -2,7 +2,7 @@ import type { VoicevoxClient } from '@kajidog/voicevox-client'
 import { applyNotationAccents, parseNotation, type SpeakResult, VoicevoxApi } from '@kajidog/voicevox-client'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import * as z from 'zod'
-import { registerToolIfEnabled } from './registration.js'
+import { isToolEnabled, registerToolIfEnabled } from './registration.js'
 import type { ToolDeps, ToolHandlerExtra } from './types.js'
 import {
   createErrorResponse,
@@ -66,7 +66,10 @@ export function registerSpeakTool(deps: ToolDeps) {
     {
       title: 'Speak',
       description:
-        'Play text as speech immediately. Use this for simple TTS — no UI, no editing. If you need a player UI or want to edit/replay segments, use voicevox_speak_player instead.',
+        'Play text as speech immediately. Use this for simple TTS — no UI, no editing.' +
+        (isToolEnabled(disabledTools, 'speak_player')
+          ? ' If you need a player UI or want to edit/replay segments, use voicevox_speak_player instead.'
+          : ''),
       inputSchema: buildSpeakInputSchema(restrictions),
       annotations: {
         readOnlyHint: false,

--- a/apps/mcp-tts/src/tools/speakers.ts
+++ b/apps/mcp-tts/src/tools/speakers.ts
@@ -1,5 +1,5 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { registerToolIfEnabled } from './registration.js'
+import { isToolEnabled, registerToolIfEnabled } from './registration.js'
 import type { ToolDeps } from './types.js'
 import { createErrorResponse, createSuccessResponse } from './utils.js'
 
@@ -68,8 +68,9 @@ export function registerSpeakerTools(deps: ToolDeps) {
     'get_speakers',
     {
       title: 'Get Speakers',
-      description:
-        'Get a list of available speakers. The returned "speaker" field is the exact ID to pass to speak.speaker',
+      description: isToolEnabled(disabledTools, 'speak')
+        ? 'Get a list of available speakers. The returned "speaker" field is the exact ID to pass to speak.speaker'
+        : 'Get a list of available speakers. The returned "speaker" field is the exact ID to pass as the speaker parameter',
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,


### PR DESCRIPTION
Tool descriptions, schema descriptions, response hints, and error
messages referenced other tools by name as static strings, so a tool
disabled via --disable-tools / --disable-groups could still be
recommended to the client (e.g. speak's description pointing to
voicevox_speak_player, or get_player_state referencing
speak_player/resynthesize_player after --disable-groups apps).

Export isToolEnabled() from registration.ts and build all cross-tool
guidance conditionally from the already-resolved disabledTools set:

- speak: mention voicevox_speak_player only when enabled
- speak_player: mention voicevox_speak only when enabled; filter the
  "Next:" response line to enabled tools (omit line when none)
- get_player_state: list only enabled viewUUID sources in description
  and schema; include the resynthesize hint only when that tool is
  enabled
- resynthesize_player: adjust description/phrases describe/error text
  to enabled tools
- get_speakers: fall back to generic wording when speak is disabled

Add registration-level tests covering enabled (regression),
--disable-groups apps, and individual disable scenarios.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012UkvSoT5gtMsRh1MUgPzkC