### PR TITLE
Fix accent notation rejecting valid input with misaligned mora boundaries

### DIFF
--- a/.changeset/tidy-accents-align.md
+++ b/.changeset/tidy-accents-align.md
@@ -8,3 +8,5 @@ Fix `phrases` (inline accent notation) rejecting valid input with "Bracket posit
 VOICEVOX runs its own morphological analysis on the katakana text, so the accent phrases it returns do not always line up with the phrase separators (`,`) in the notation — `アクセントシ` comes back split as `アクセント` + `シ`, for instance. Accent phrases were matched to notation phrases by index, so the bracket position was looked up inside the wrong accent phrase and a correct notation could fail depending on the words used.
 
 Accent phrases are now regrouped to follow the notation's phrase boundaries before the accent is applied: a notation phrase spanning several accent phrases is merged into one, and an accent phrase spanning several notation phrases is split. If the notation cannot be matched against the moras (non-katakana text, for example), the previous index-based behaviour is used as a fallback.
+
+Omitting the brackets now restores VOICEVOX's own accent phrase segmentation as well as its accent values, so an accent set with brackets can be reset afterwards. Flat accents (`accent: 0`) are also kept as-is when a phrase is split.

--- a/.changeset/tidy-accents-align.md
+++ b/.changeset/tidy-accents-align.md
@@ -1,0 +1,10 @@
+---
+'@kajidog/voicevox-client': patch
+'@kajidog/mcp-tts-voicevox': patch
+---
+
+Fix `phrases` (inline accent notation) rejecting valid input with "Bracket position N does not align with any mora boundary".
+
+VOICEVOX runs its own morphological analysis on the katakana text, so the accent phrases it returns do not always line up with the phrase separators (`,`) in the notation — `アクセントシ` comes back split as `アクセント` + `シ`, for instance. Accent phrases were matched to notation phrases by index, so the bracket position was looked up inside the wrong accent phrase and a correct notation could fail depending on the words used.
+
+Accent phrases are now regrouped to follow the notation's phrase boundaries before the accent is applied: a notation phrase spanning several accent phrases is merged into one, and an accent phrase spanning several notation phrases is split. If the notation cannot be matched against the moras (non-katakana text, for example), the previous index-based behaviour is used as a fallback.

--- a/packages/voicevox-client/src/__tests__/accent-utils.test.ts
+++ b/packages/voicevox-client/src/__tests__/accent-utils.test.ts
@@ -403,3 +403,136 @@ describe('normalizeUserDictionaryWords', () => {
     ])
   })
 })
+
+// ---------------------------------------------------------------------------
+// notation のフレーズ区切りと VOICEVOX のアクセント句区切りがずれるケース
+// ---------------------------------------------------------------------------
+
+describe('applyNotationAccents: アクセント句の区切りが notation と一致しない場合', () => {
+  it('1フレーズが複数アクセント句に分割されていても括弧位置を解決できる', () => {
+    // VOICEVOX は "アクセントシ" を ["アクセント", "シ"] に分割することがある。
+    // 旧実装では accentPhrases[0] に対して括弧位置5を探すため
+    // "Bracket position 5 does not align with any mora boundary" になっていた。
+    const parsed = parseNotation('アクセント[シ]')
+    const accentPhrases = [makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト'], 1), makeAccentPhrase(['シ'], 1)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(1)
+    expect(result[0].moras.map((m) => m.text).join('')).toBe('アクセントシ')
+    expect(result[0].accent).toBe(6)
+  })
+
+  it('複数フレーズがそれぞれ分割されていても正しく対応付ける', () => {
+    const parsed = parseNotation('アクセント[シ]テエノ,カクニン[デ]ス')
+    const accentPhrases = [
+      makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト'], 1),
+      makeAccentPhrase(['シ', 'テ', 'エ', 'ノ'], 1),
+      makeAccentPhrase(['カ', 'ク', 'ニ', 'ン'], 1),
+      makeAccentPhrase(['デ', 'ス'], 1),
+    ]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[0].moras.map((m) => m.text).join('')).toBe('アクセントシテエノ')
+    expect(result[0].accent).toBe(6)
+    expect(result[1].moras.map((m) => m.text).join('')).toBe('カクニンデス')
+    expect(result[1].accent).toBe(5)
+  })
+
+  it('1つのアクセント句が複数フレーズにまたがる場合は分割する', () => {
+    const parsed = parseNotation('テ[ス]ト,ロ[ク]')
+    const accentPhrases = [makeAccentPhrase(['テ', 'ス', 'ト', 'ロ', 'ク'], 1)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[0].moras.map((m) => m.text).join('')).toBe('テスト')
+    expect(result[0].accent).toBe(2)
+    expect(result[1].moras.map((m) => m.text).join('')).toBe('ロク')
+    expect(result[1].accent).toBe(2)
+  })
+
+  it('結合時は末尾の pause_mora を引き継ぐ', () => {
+    const parsed = parseNotation('アクセント[シ]')
+    const accentPhrases: AccentPhrase[] = [
+      makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト'], 1),
+      { ...makeAccentPhrase(['シ'], 1), pause_mora: makeMora('、'), is_interrogative: true },
+    ]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result[0].pause_mora?.text).toBe('、')
+    expect(result[0].is_interrogative).toBe(true)
+  })
+
+  it('分割時は前半に pause_mora / is_interrogative を引き継がない', () => {
+    const parsed = parseNotation('テ[ス]ト,ロ[ク]')
+    const accentPhrases: AccentPhrase[] = [
+      {
+        ...makeAccentPhrase(['テ', 'ス', 'ト', 'ロ', 'ク'], 1),
+        pause_mora: makeMora('、'),
+        is_interrogative: true,
+      },
+    ]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result[0].pause_mora).toBeUndefined()
+    expect(result[0].is_interrogative).toBe(false)
+    expect(result[1].pause_mora?.text).toBe('、')
+    expect(result[1].is_interrogative).toBe(true)
+  })
+
+  it('[]なしのフレーズは VOICEVOX のアクセント句分割を維持する', () => {
+    const parsed = parseNotation('アクセントシ')
+    const accentPhrases = [makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト'], 3), makeAccentPhrase(['シ'], 1)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[0].accent).toBe(3)
+    expect(result[1].accent).toBe(1)
+  })
+
+  it('notation より長い分の AccentPhrase はそのまま後ろに残る', () => {
+    const parsed = parseNotation('テ[ス]ト')
+    const accentPhrases = [makeAccentPhrase(['テ', 'ス', 'ト', 'ロ', 'ク'], 4)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[0].moras.map((m) => m.text).join('')).toBe('テスト')
+    expect(result[0].accent).toBe(2)
+    expect(result[1].moras.map((m) => m.text).join('')).toBe('ロク')
+    // 元の accent 4 は分割後の位置(1)に付け替わる
+    expect(result[1].accent).toBe(1)
+  })
+
+  it('テキストを対応付けられない場合は従来のインデックス対応にフォールバックする', () => {
+    // モーラ数が notation より少なく、区切り直しができないケース
+    const parsed = parseNotation('[ア]イウエオ')
+    const accentPhrases = [makeAccentPhrase(['ア', 'イ'], 2)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(1)
+    expect(result[0].accent).toBe(1)
+  })
+
+  it('モーラ境界と一致しない括弧位置はエラーのまま', () => {
+    const parsed = parseNotation('キ[ョ]ウ')
+    const accentPhrases = [makeAccentPhrase(['キョ', 'ウ'], 1)]
+    expect(() => applyNotationAccents(parsed, accentPhrases)).toThrow()
+  })
+})
+
+describe('applyNotationAccents: 読点（pause_mora）を含む notation', () => {
+  it('1フレーズの中に読点があるとモーラと対応付けできずエラーになる', () => {
+    // 読点は moras ではなく pause_mora として表現されるため、notation の
+    // 文字位置とモーラ列がずれる。フレーズは "," で区切る必要がある。
+    const parsed = parseNotation('コンニチワ、セ[カ]イ')
+    const accentPhrases: AccentPhrase[] = [
+      { ...makeAccentPhrase(['コ', 'ン', 'ニ', 'チ', 'ワ'], 3), pause_mora: makeMora('、') },
+      makeAccentPhrase(['セ', 'カ', 'イ'], 1),
+    ]
+    expect(() => applyNotationAccents(parsed, accentPhrases)).toThrow('does not align')
+  })
+
+  it('"," で区切れば読点付きのアクセント句も扱える', () => {
+    const parsed = parseNotation('コンニチワ,セ[カ]イ')
+    const accentPhrases: AccentPhrase[] = [
+      { ...makeAccentPhrase(['コ', 'ン', 'ニ', 'チ', 'ワ'], 3), pause_mora: makeMora('、') },
+      makeAccentPhrase(['セ', 'カ', 'イ'], 1),
+    ]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[0].pause_mora?.text).toBe('、')
+    expect(result[1].accent).toBe(2)
+  })
+})

--- a/packages/voicevox-client/src/__tests__/accent-utils.test.ts
+++ b/packages/voicevox-client/src/__tests__/accent-utils.test.ts
@@ -536,3 +536,54 @@ describe('applyNotationAccents: 読点（pause_mora）を含む notation', () =>
     expect(result[1].accent).toBe(2)
   })
 })
+
+describe('applyNotationAccents: 平板型(accent=0)の維持', () => {
+  it('フレーズ分割で平板型が頭高型に変わらない', () => {
+    const parsed = parseNotation('テスト,ロク')
+    const accentPhrases = [makeAccentPhrase(['テ', 'ス', 'ト', 'ロ', 'ク'], 0)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[0].accent).toBe(0)
+    expect(result[1].accent).toBe(0)
+  })
+
+  it('notation より長い余り部分でも平板型を維持する', () => {
+    const parsed = parseNotation('テスト')
+    const accentPhrases = [makeAccentPhrase(['テ', 'ス', 'ト', 'ロ', 'ク'], 0)]
+    const result = applyNotationAccents(parsed, accentPhrases)
+    expect(result).toHaveLength(2)
+    expect(result[1].moras.map((m) => m.text).join('')).toBe('ロク')
+    expect(result[1].accent).toBe(0)
+  })
+})
+
+describe('applyNotationAccents: [] 省略時のデフォルト復元', () => {
+  it('既存とデフォルトで区切りが違ってもデフォルトに戻せる', () => {
+    // [] 付き編集で結合されたアクセント句が base になっているケース。
+    // 括弧を外したらデフォルト（VOICEVOX の分割とアクセント）に戻る必要がある。
+    const parsed = parseNotation('アクセントシテエノ')
+    const edited = [makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト', 'シ', 'テ', 'エ', 'ノ'], 6)]
+    const defaults = [
+      makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト'], 1),
+      makeAccentPhrase(['シ', 'テ', 'エ', 'ノ'], 2),
+    ]
+    const result = applyNotationAccents(parsed, edited, defaults)
+    expect(result).toHaveLength(2)
+    expect(result[0].moras.map((m) => m.text).join('')).toBe('アクセント')
+    expect(result[0].accent).toBe(1)
+    expect(result[1].moras.map((m) => m.text).join('')).toBe('シテエノ')
+    expect(result[1].accent).toBe(2)
+  })
+
+  it('[] ありのフレーズはデフォルトに戻さず括弧位置を優先する', () => {
+    const parsed = parseNotation('アクセント[シ]テエノ')
+    const edited = [makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト', 'シ', 'テ', 'エ', 'ノ'], 1)]
+    const defaults = [
+      makeAccentPhrase(['ア', 'ク', 'セ', 'ン', 'ト'], 1),
+      makeAccentPhrase(['シ', 'テ', 'エ', 'ノ'], 2),
+    ]
+    const result = applyNotationAccents(parsed, edited, defaults)
+    expect(result).toHaveLength(1)
+    expect(result[0].accent).toBe(6)
+  })
+})

--- a/packages/voicevox-client/src/accent-utils.ts
+++ b/packages/voicevox-client/src/accent-utils.ts
@@ -140,14 +140,172 @@ export function resolveAccentFromMoras(moras: Mora[], bracketCharIndex: number, 
 }
 
 /**
+ * AccentPhrase から一部のモーラを切り出して新しい AccentPhrase を作る。
+ * 末尾まで使い切らない切り出しでは pause_mora / is_interrogative は引き継がない
+ * （無音や疑問形はフレーズ末尾に付くもののため）。
+ */
+function sliceAccentPhrase(source: AccentPhrase, start: number, end: number): AccentPhrase {
+  if (start === 0 && end === source.moras.length) {
+    return { ...source }
+  }
+  const moras = source.moras.slice(start, end)
+  const sliced: AccentPhrase = {
+    ...source,
+    moras,
+    accent: Math.min(Math.max(source.accent - start, 1), moras.length),
+  }
+  if (end !== source.moras.length) {
+    sliced.pause_mora = undefined
+    sliced.is_interrogative = false
+  }
+  return sliced
+}
+
+/**
+ * 複数の AccentPhrase を1つに結合する。accent は呼び出し側で上書きする前提。
+ * 無音・疑問形は末尾のものを引き継ぐ。
+ */
+function mergeAccentPhrases(phrases: AccentPhrase[]): AccentPhrase {
+  const last = phrases[phrases.length - 1]
+  if (phrases.length === 1) {
+    return { ...last }
+  }
+  return {
+    ...last,
+    moras: phrases.flatMap((p) => p.moras),
+  }
+}
+
+export interface RegroupedAccentPhrases {
+  /** parsedPhrases と同じ並びのグループ。1フレーズが複数 AccentPhrase にまたがることがある */
+  groups: AccentPhrase[][]
+  /** notation が言及しなかった余りの AccentPhrase */
+  rest: AccentPhrase[]
+}
+
+/**
+ * VOICEVOX が返した AccentPhrase[] を notation のフレーズ区切りに合わせて組み直す。
+ *
+ * VOICEVOX はカタカナ列も形態素解析するため、アクセント句の区切りが notation の
+ * 区切りと一致するとは限らない（例: "アクセントシ" → ["アクセント", "シ"]）。
+ * インデックスで 1:1 対応させると括弧の文字位置が別のアクセント句に当たり、
+ * 正しい表記でも "does not align with any mora boundary" になってしまう。
+ * ここではモーラのテキストを数えて区切り直し、必要なら AccentPhrase を分割する
+ * （結合は applyNotationAccents 側で行う）。
+ *
+ * 1フレーズの中に読点（無音）が入る場合は moras に現れないため対応付けできない。
+ * モーラ境界とフレーズ境界が一致しない場合や、モーラ数が足りない場合は null を返す
+ * （カタカナ以外を含む notation など。呼び出し側は従来のインデックス対応に退避する）。
+ */
+export function regroupAccentPhrasesByNotation(
+  parsedPhrases: ParsedPhrase[],
+  accentPhrases: AccentPhrase[]
+): RegroupedAccentPhrases | null {
+  const groups: AccentPhrase[][] = []
+  let phraseIndex = 0
+  let moraOffset = 0
+
+  for (const parsed of parsedPhrases) {
+    // notation の方が多い場合、余ったフレーズは無視する
+    if (phraseIndex >= accentPhrases.length) break
+
+    let remaining = parsed.cleanText.length
+    const group: AccentPhrase[] = []
+
+    while (remaining > 0) {
+      if (phraseIndex >= accentPhrases.length) return null
+
+      const source = accentPhrases[phraseIndex]
+      let taken = 0
+      let consumed = 0
+      while (moraOffset + taken < source.moras.length && consumed < remaining) {
+        consumed += source.moras[moraOffset + taken].text.length
+        taken += 1
+      }
+      // モーラ境界がフレーズ境界と一致しない
+      if (taken === 0 || consumed > remaining) return null
+
+      group.push(sliceAccentPhrase(source, moraOffset, moraOffset + taken))
+      remaining -= consumed
+
+      if (moraOffset + taken >= source.moras.length) {
+        phraseIndex += 1
+        moraOffset = 0
+      } else {
+        moraOffset += taken
+      }
+    }
+
+    groups.push(group)
+  }
+
+  const rest: AccentPhrase[] = []
+  if (phraseIndex < accentPhrases.length) {
+    if (moraOffset > 0) {
+      const source = accentPhrases[phraseIndex]
+      rest.push(sliceAccentPhrase(source, moraOffset, source.moras.length))
+      phraseIndex += 1
+    }
+    rest.push(...accentPhrases.slice(phraseIndex))
+  }
+
+  return { groups, rest }
+}
+
+/**
  * ParsedPhrase[] のアクセント指定を AccentPhrase[] に適用する。
- * 左から1:1で対応。数が合わない場合、余分は無視/デフォルト維持。
+ *
+ * notation のフレーズ区切りを正として AccentPhrase を組み直してから適用する。
+ * `[]` を含むフレーズが複数のアクセント句にまたがっていた場合は1つに結合し、
+ * 逆に1つのアクセント句が複数フレーズにまたがっていた場合は分割する。
  *
  * bracketCharIndex === null（[] 省略）のフレーズ:
  *   - defaultAccentPhrases が渡された場合 → そのアクセント値（VOICEVOX自動判定）を使用
  *   - defaultAccentPhrases が未指定の場合 → accentPhrases のアクセント値をそのまま維持
+ *   いずれの場合も VOICEVOX が決めたアクセント句の区切りをそのまま残す。
  */
 export function applyNotationAccents(
+  parsedPhrases: ParsedPhrase[],
+  accentPhrases: AccentPhrase[],
+  defaultAccentPhrases?: AccentPhrase[]
+): AccentPhrase[] {
+  const regrouped = regroupAccentPhrasesByNotation(parsedPhrases, accentPhrases)
+  if (!regrouped) {
+    return applyNotationAccentsByIndex(parsedPhrases, accentPhrases, defaultAccentPhrases)
+  }
+
+  const defaultGroups = defaultAccentPhrases
+    ? regroupAccentPhrasesByNotation(parsedPhrases, defaultAccentPhrases)?.groups
+    : undefined
+
+  const result: AccentPhrase[] = []
+
+  regrouped.groups.forEach((group, i) => {
+    const parsed = parsedPhrases[i]
+
+    if (parsed.bracketCharIndex === null) {
+      const defaults = defaultGroups?.[i]
+      const useDefaults = defaults !== undefined && defaults.length === group.length
+      for (const [j, phrase] of group.entries()) {
+        result.push(useDefaults ? { ...phrase, accent: defaults[j].accent } : phrase)
+      }
+      return
+    }
+
+    const merged = mergeAccentPhrases(group)
+    merged.accent = resolveAccentFromMoras(merged.moras, parsed.bracketCharIndex, parsed.bracketLength)
+    result.push(merged)
+  })
+
+  result.push(...regrouped.rest)
+  return result
+}
+
+/**
+ * インデックスで 1:1 対応させる旧方式。
+ * regroupAccentPhrasesByNotation がテキストを対応付けられなかった場合の退避先。
+ */
+function applyNotationAccentsByIndex(
   parsedPhrases: ParsedPhrase[],
   accentPhrases: AccentPhrase[],
   defaultAccentPhrases?: AccentPhrase[]

--- a/packages/voicevox-client/src/accent-utils.ts
+++ b/packages/voicevox-client/src/accent-utils.ts
@@ -152,7 +152,9 @@ function sliceAccentPhrase(source: AccentPhrase, start: number, end: number): Ac
   const sliced: AccentPhrase = {
     ...source,
     moras,
-    accent: Math.min(Math.max(source.accent - start, 1), moras.length),
+    // accent 0 は平板型を表すのでそのまま維持する。
+    // それ以外は切り出し後の位置に付け替える（範囲外は端に丸める）。
+    accent: source.accent === 0 ? 0 : Math.min(Math.max(source.accent - start, 1), moras.length),
   }
   if (end !== source.moras.length) {
     sliced.pause_mora = undefined
@@ -260,7 +262,7 @@ export function regroupAccentPhrasesByNotation(
  * 逆に1つのアクセント句が複数フレーズにまたがっていた場合は分割する。
  *
  * bracketCharIndex === null（[] 省略）のフレーズ:
- *   - defaultAccentPhrases が渡された場合 → そのアクセント値（VOICEVOX自動判定）を使用
+ *   - defaultAccentPhrases が渡された場合 → その区切りとアクセント値（VOICEVOX自動判定）に戻す
  *   - defaultAccentPhrases が未指定の場合 → accentPhrases のアクセント値をそのまま維持
  *   いずれの場合も VOICEVOX が決めたアクセント句の区切りをそのまま残す。
  */
@@ -284,11 +286,11 @@ export function applyNotationAccents(
     const parsed = parsedPhrases[i]
 
     if (parsed.bracketCharIndex === null) {
+      // [] 省略は「VOICEVOX の自動判定に戻す」意味なので、アクセント句の区切りごと
+      // デフォルト側を採用する。区切り数が合うときだけ accent を写す方式だと、
+      // 結合済みのアクセント句（[] 付き編集の結果）を戻せなくなる。
       const defaults = defaultGroups?.[i]
-      const useDefaults = defaults !== undefined && defaults.length === group.length
-      for (const [j, phrase] of group.entries()) {
-        result.push(useDefaults ? { ...phrase, accent: defaults[j].accent } : phrase)
-      }
+      result.push(...(defaults ?? group))
       return
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where valid `phrases` (inline accent notation) would be rejected with "Bracket position N does not align with any mora boundary" when VOICEVOX's morphological analysis split words differently than the notation's phrase boundaries.

For example, `アクセント[シ]` would fail because VOICEVOX returns `["アクセント", "シ"]` as separate accent phrases, but the bracket position was looked up in the first phrase only.

## Changes

- **New helper functions:**
  - `sliceAccentPhrase()` — Extract a portion of an accent phrase, adjusting accent position and clearing trailing pause/interrogative markers
  - `mergeAccentPhrases()` — Combine multiple accent phrases into one, preserving trailing pause/interrogative from the last phrase
  - `regroupAccentPhrasesByNotation()` — Regroup VOICEVOX's accent phrases to match notation phrase boundaries by counting mora text. Returns `null` if text cannot be matched (non-katakana, misaligned boundaries, etc.)

- **Updated `applyNotationAccents()`:**
  - Now calls `regroupAccentPhrasesByNotation()` to align accent phrases with notation boundaries
  - Merges accent phrases that span a single notation phrase (with brackets)
  - Splits accent phrases that span multiple notation phrases
  - Falls back to index-based matching (`applyNotationAccentsByIndex()`) if text matching fails
  - Preserves VOICEVOX's accent phrase boundaries for notation phrases without brackets (`[]` omitted)

- **New fallback function:**
  - `applyNotationAccentsByIndex()` — Extracted from original `applyNotationAccents()` logic for backward compatibility when text matching is impossible

## Implementation Details

- Mora text is counted character-by-character to find phrase boundaries; if a boundary doesn't align with a mora boundary, the function returns `null` and falls back to index matching
- Pause mora (`、`) and interrogative markers are only preserved on the final phrase after merging/splitting
- Notation phrases without brackets retain VOICEVOX's original accent phrase structure (no merging/splitting)
- Comprehensive test coverage added for split/merged phrases, pause mora handling, and fallback behavior

## Testing

Added 13 new test cases covering:
- Phrases split across multiple accent phrases
- Phrases spanning multiple accent phrases
- Pause mora preservation during merge/split
- Fallback to index matching when text cannot be aligned
- Error handling for misaligned mora boundaries

https://claude.ai/code/session_012xKGvwzCA2ymu9WFZ89MN7