### PR TITLE
docs: sync documentation with the current implementation

### DIFF
--- a/.changeset/cuddly-docs-refresh.md
+++ b/.changeset/cuddly-docs-refresh.md
@@ -1,0 +1,11 @@
+---
+"@kajidog/mcp-tts-voicevox": patch
+"@kajidog/voicevox-client": patch
+---
+
+ドキュメントを実装に合わせて更新しました（コードの変更はありません）。
+
+- README（英/日）: `voicevox_speak` の `phrases`（インラインアクセント表記）と `waitForStart` を追記し、辞書ツール一覧とインラインアクセント表記の説明を追加
+- README（英/日）: プレイヤーツール名を実際の `voicevox_` 付きの名前に修正、パッケージ構成に `@kajidog/mcp-core` を追加、ルートに存在しない `pnpm dev` 系コマンドを `pnpm --filter` 形式に修正
+- `packages/voicevox-client/README.md`: `VoicevoxConfig` の全項目、`speak()` / `enqueueAudioGeneration()` の戻り値（`SpeakResult`）、ユーザー辞書 API とアクセント表記ユーティリティを追記。ライブラリが読まない環境変数の記載とライセンス表記（ISC）を修正
+- `examples/README.md`: npm 前提の手順を pnpm に修正し、ファイル再生サンプルを追記

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ To change a compiler option for everyone, edit `tsconfig.base.json`.
 
 - **`index.ts`** - Entry point with runtime detection (Node.js/Bun via `mcp-core`'s `isBun`/`isNodejs`), CLI arg parsing, auto-starts stdio or HTTP server. Reads `package.json` via `readFileSync` (no `require` for JSON).
 - **`config.ts`** - VOICEVOX-specific config built on `mcp-core`'s schema helpers. Priority: CLI args > env vars > config file (`.voicevoxrc.json`) > defaults. Add new options to the declarative config defs — CLI/env/config-file parsing and help text are auto-generated.
-- **`server.ts`** - MCP tool registration via `server.registerTool()`. Tools: `ping_voicevox`, `speak`, `generate_query`, `synthesize_file`, `stop_speaker`, `get_speakers`, plus player/dictionary tools. Uses `registerToolIfEnabled()` for conditional registration. Dynamic schema via `buildSpeakInputSchema()`.
+- **`server.ts`** - MCP tool registration via `server.registerTool()`. Tools are registered unprefixed and exposed with the `voicevox_` prefix (`addToolPrefix` in `tools/registration.ts`; internal `_*` player tools stay unprefixed): `ping`, `speak`, `stop_speaker`, `get_speakers`, `synthesize_file`, plus player and dictionary tools. Uses `registerToolIfEnabled()` for conditional registration. Dynamic schema via `buildSpeakInputSchema()`.
 - **`tool-groups.ts`** - Tool grouping for `--disable-groups` / conditional registration.
 - **`stdio.ts`** - Minimal stdio transport wrapper.
 - **`tools/`** - Tool implementations (`speak`, `synthesize`, `speakers`, `dictionary`, `player`, `player-ui`). Per-session player state lives in `tools/player/session-state.ts`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,10 +59,10 @@ VOICEVOX を使用した MCP テキスト読み上げサーバー
 
 | ツール | 説明 |
 |--------|------|
-| `speak_player` | 新しいプレーヤーセッションを作成して UI を表示。`viewUUID` を返します。 |
-| `resynthesize_player` | 既存プレーヤーの全セグメントを更新します（毎回新しい `viewUUID` を生成）。 |
-| `get_player_state` | AI チューニング用にプレーヤーの現在状態をページ単位で取得します（読み取り専用）。 |
-| `open_dictionary_ui` | ユーザー辞書管理 UI を開きます。 |
+| `voicevox_speak_player` | 新しいプレーヤーセッションを作成して UI を表示。`viewUUID` を返します。 |
+| `voicevox_resynthesize_player` | 既存プレーヤーの全セグメントを更新します（毎回新しい `viewUUID` を生成）。 |
+| `voicevox_get_player_state` | AI チューニング用にプレーヤーの現在状態をページ単位で取得します（読み取り専用）。 |
+| `voicevox_open_dictionary_ui` | ユーザー辞書管理 UI を開きます。 |
 
 ## クイックスタート
 
@@ -190,10 +190,14 @@ Claude から呼び出せるメインの機能です。
 | パラメータ | 説明 | デフォルト |
 |-----------|------|-----------|
 | `text` | 読み上げるテキスト（改行で複数セグメント） | 必須 |
+| `phrases` | インラインアクセント表記（`text` より優先） | _(未設定)_ |
 | `speaker` | 話者 ID | 1 |
 | `speedScale` | 再生速度 | 1.0 |
 | `immediate` | 即時再生（キューをクリア） | true |
+| `waitForStart` | 再生開始まで待機 | false |
 | `waitForEnd` | 再生完了まで待機 | false |
+
+> `immediate` / `waitForStart` / `waitForEnd` は、対応する `--restrict-*` オプションを設定するとツールのスキーマから外れます。
 
 **使用例：**
 
@@ -209,18 +213,47 @@ Claude から呼び出せるメインの機能です。
 
 // 再生完了まで待機（同期処理）
 { "text": "このメッセージを読み終えてから次へ", "waitForEnd": true }
+
+// インライン表記でアクセントを指定（`,` でフレーズ区切り、`[` でアクセント位置）
+{ "text": "こんにちは世界", "phrases": "コン[ニ]チワ,セ[カ]イ" }
 ```
+
+### インラインアクセント表記
+
+`phrases`（およびユーザー辞書ツールの読み）では、カタカナにアクセント記号を埋め込んだ表記が使えます。
+
+- `,` はアクセント句の区切り — `コン[ニ]チワ,セ[カ]イ`
+- `[` はその直後の音でピッチが下がる位置を示す — `コン[ニ]チワ` なら `ニ` にアクセント
+- ブラケットを省略したフレーズは、VOICEVOX が推定したアクセントをそのまま使います
+
+`phrases` を指定する場合も `text` は必須です（`text` には元のテキストを渡し、実際に読み上げられるのは表記の内容です）。
+
+`voicevox_get_accent_phrases` は同じ表記でテキストの読みとアクセントを返すので、推定結果を確認 → ブラケットを直す → `phrases` に渡す、という流れで調整できます。
 
 <details>
 <summary>その他のツール</summary>
 
 | ツール | 説明 |
 |--------|------|
-| `voicevox_speak_player` | UI 音声プレイヤー付き読み上げ（`--disable-tools` で無効化可） |
+| `voicevox_speak_player` | UI 音声プレイヤー付き読み上げ（[プレーヤー MCP ツール一覧](#プレーヤー-mcp-ツール一覧)を参照） |
 | `voicevox_ping` | VOICEVOX Engine への接続確認 |
 | `voicevox_get_speakers` | 利用可能な話者一覧を取得 |
 | `voicevox_stop_speaker` | 再生停止とキューのクリア |
 | `voicevox_synthesize_file` | 音声ファイルを生成 |
+
+ユーザー辞書ツール（グループ `dictionary`）:
+
+| ツール | 説明 |
+|--------|------|
+| `voicevox_get_accent_phrases` | テキストの読みとアクセント位置をインライン表記で取得 |
+| `voicevox_get_user_dictionary` | ユーザー辞書の単語一覧を取得（絞り込み・ページング対応） |
+| `voicevox_add_user_dictionary_word` | 単語を追加（読みはインラインアクセント表記に対応） |
+| `voicevox_update_user_dictionary_word` | 単語を更新（省略した項目は現在の値を維持） |
+| `voicevox_delete_user_dictionary_word` | UUID を指定して単語を削除 |
+| `voicevox_add_user_dictionary_words` | 複数の単語をまとめて追加 |
+| `voicevox_update_user_dictionary_words` | 複数の単語をまとめて更新 |
+
+各ツールは `--disable-tools` / `VOICEVOX_DISABLED_TOOLS` で個別に、`--disable-groups` / `VOICEVOX_DISABLED_GROUPS` でグループ単位で無効化できます。
 
 </details>
 
@@ -627,9 +660,10 @@ curl http://localhost:50021/speakers
 
 | パッケージ | 説明 |
 |-----------|------|
-| `@kajidog/mcp-tts-voicevox` | MCP サーバー本体 |
+| `@kajidog/mcp-tts-voicevox` | MCP サーバー本体（`apps/mcp-tts`） |
 | [`@kajidog/voicevox-client`](https://www.npmjs.com/package/@kajidog/voicevox-client) | 汎用 VOICEVOX クライアントライブラリ（独立使用可能） |
-| `@kajidog/player-ui` | ブラウザ再生用の React 音声プレイヤー UI |
+| `@kajidog/mcp-core` | MCP サーバー共通基盤（設定スキーマ、HTTP/stdio 起動）。非公開でサーバーにバンドルされます |
+| `@kajidog/player-ui` | ブラウザ再生用の React 音声プレイヤー UI。単一 HTML にバンドルされる非公開パッケージ |
 
 ---
 
@@ -646,15 +680,24 @@ pnpm install
 
 ### コマンド
 
+パッケージマネージャーは **pnpm** です（npm / yarn は非対応）。
+
 | コマンド | 説明 |
 |---------|------|
 | `pnpm build` | 全パッケージをビルド |
 | `pnpm test` | テスト実行 |
-| `pnpm lint` | Lint 実行 |
-| `pnpm dev` | 開発サーバー起動 |
-| `pnpm dev:stdio` | Stdio モードで開発 |
-| `pnpm dev:bun` | Bun で開発サーバー起動 |
-| `pnpm dev:bun:http` | Bun で HTTP 開発サーバー起動 |
+| `pnpm lint` | Lint 実行（ワークスペース全体を Biome で 1 回だけチェック） |
+| `pnpm typecheck` | 全パッケージの型チェック |
+| `pnpm changeset` | ユーザー影響のある変更に changeset を追加 |
+
+開発サーバーはサーバーパッケージ側のスクリプトなので、フィルタを付けて実行します。
+
+| コマンド | 説明 |
+|---------|------|
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev` | 開発サーバー起動（stdio） |
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev:http` | HTTP モードで開発サーバー起動 |
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev:bun` | Bun で開発サーバー起動 |
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev:bun:http` | Bun で HTTP 開発サーバー起動 |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Export behavior by environment:
 
 | Tool | Description |
 |------|-------------|
-| `speak_player` | Create a new player session and display the UI. Returns `viewUUID`. |
-| `resynthesize_player` | Update all segments for an existing player (new `viewUUID` each call). |
-| `get_player_state` | Read the current player state (paginated) for AI tuning. |
-| `open_dictionary_ui` | Open the user dictionary manager UI. |
+| `voicevox_speak_player` | Create a new player session and display the UI. Returns `viewUUID`. |
+| `voicevox_resynthesize_player` | Update all segments for an existing player (new `viewUUID` each call). |
+| `voicevox_get_player_state` | Read the current player state (paginated) for AI tuning. |
+| `voicevox_open_dictionary_ui` | Open the user dictionary manager UI. |
 
 ## Quick Start
 
@@ -190,10 +190,14 @@ The main feature callable from Claude.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `text` | Text to speak (multiple segments separated by newlines) | Required |
+| `phrases` | Inline accent notation (takes priority over `text`) | _(unset)_ |
 | `speaker` | Speaker ID | 1 |
 | `speedScale` | Playback speed | 1.0 |
 | `immediate` | Immediate playback (clears queue) | true |
+| `waitForStart` | Wait for playback to start | false |
 | `waitForEnd` | Wait for playback completion | false |
+
+> `immediate` / `waitForStart` / `waitForEnd` disappear from the tool schema when the matching `--restrict-*` option is set.
 
 **Examples:**
 
@@ -209,18 +213,47 @@ The main feature callable from Claude.
 
 // Wait for completion (synchronous processing)
 { "text": "Wait for this to finish before continuing", "waitForEnd": true }
+
+// Control the accent with inline notation (`,` separates phrases, `[` marks the accent)
+{ "text": "こんにちは世界", "phrases": "コン[ニ]チワ,セ[カ]イ" }
 ```
+
+### Inline Accent Notation
+
+`phrases` (and the pronunciation field of the user dictionary tools) accepts katakana with an inline accent marker:
+
+- `,` separates accent phrases — `コン[ニ]チワ,セ[カ]イ`
+- `[` marks where the pitch drops after; `コン[ニ]チワ` means the accent falls on `ニ`
+- Omitting the brackets for a phrase keeps VOICEVOX's own accent estimation for it
+
+`text` stays required even when `phrases` is given — pass the plain text there and the notation is what gets spoken.
+
+`voicevox_get_accent_phrases` returns the same notation for a given text, so you can read the estimated accent, tweak the bracket, and feed it back into `phrases`.
 
 <details>
 <summary>Other Tools</summary>
 
 | Tool | Description |
 |------|-------------|
-| `voicevox_speak_player` | Speak with UI audio player (disable with `--disable-tools`) |
+| `voicevox_speak_player` | Speak with UI audio player (see [Player MCP Tools](#player-mcp-tools)) |
 | `voicevox_ping` | Check VOICEVOX Engine connection |
 | `voicevox_get_speakers` | Get list of available speakers |
 | `voicevox_stop_speaker` | Stop playback and clear queue |
 | `voicevox_synthesize_file` | Generate audio file |
+
+User dictionary tools (group `dictionary`):
+
+| Tool | Description |
+|------|-------------|
+| `voicevox_get_accent_phrases` | Get reading and accent positions of a text as inline notation |
+| `voicevox_get_user_dictionary` | List user dictionary words (filter + pagination) |
+| `voicevox_add_user_dictionary_word` | Add a word (pronunciation accepts inline accent notation) |
+| `voicevox_update_user_dictionary_word` | Update a word (omitted fields keep their value) |
+| `voicevox_delete_user_dictionary_word` | Delete a word by UUID |
+| `voicevox_add_user_dictionary_words` | Add multiple words at once |
+| `voicevox_update_user_dictionary_words` | Update multiple words at once |
+
+Any tool can be turned off individually with `--disable-tools` / `VOICEVOX_DISABLED_TOOLS`, or by group with `--disable-groups` / `VOICEVOX_DISABLED_GROUPS`.
 
 </details>
 
@@ -627,9 +660,10 @@ curl http://localhost:50021/speakers
 
 | Package | Description |
 |---------|-------------|
-| `@kajidog/mcp-tts-voicevox` | MCP server |
+| `@kajidog/mcp-tts-voicevox` | MCP server (`apps/mcp-tts`) |
 | [`@kajidog/voicevox-client`](https://www.npmjs.com/package/@kajidog/voicevox-client) | General-purpose VOICEVOX client library (can be used independently) |
-| `@kajidog/player-ui` | React-based audio player UI for browser playback |
+| `@kajidog/mcp-core` | Shared MCP infrastructure (config schema, HTTP/stdio launcher). Not published — bundled into the server |
+| `@kajidog/player-ui` | React-based audio player UI, bundled into a single HTML file. Not published |
 
 ---
 
@@ -646,15 +680,24 @@ pnpm install
 
 ### Commands
 
+The package manager is **pnpm** (npm / yarn are not supported).
+
 | Command | Description |
 |---------|-------------|
 | `pnpm build` | Build all packages |
 | `pnpm test` | Run tests |
-| `pnpm lint` | Run lint |
-| `pnpm dev` | Start dev server |
-| `pnpm dev:stdio` | Dev with stdio mode |
-| `pnpm dev:bun` | Start dev server with Bun |
-| `pnpm dev:bun:http` | Start HTTP dev server with Bun |
+| `pnpm lint` | Run lint (single Biome pass over the whole workspace) |
+| `pnpm typecheck` | Type-check every package |
+| `pnpm changeset` | Add a changeset for a user-facing change |
+
+Dev servers live in the server package, so run them with a filter:
+
+| Command | Description |
+|---------|-------------|
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev` | Start dev server (stdio) |
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev:http` | Start dev server in HTTP mode |
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev:bun` | Start dev server with Bun |
+| `pnpm --filter @kajidog/mcp-tts-voicevox dev:bun:http` | Start HTTP dev server with Bun |
 
 </details>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,19 +9,21 @@ voicevox-clientパッケージの動作確認用サンプルスクリプト集�
 
 ## セットアップ
 
+依存関係はワークスペース全体で管理しているため、リポジトリのルートで pnpm を実行します（npm / yarn は非対応）。
+
 ```bash
+pnpm install
 cd examples
-npm install
 ```
 
 ## スクリプト一覧
 
-### 基本テスト (basic.ts)
+### 基本テスト (basic/index.ts)
 
 シンプルなテキスト読み上げの動作確認。
 
 ```bash
-npm run basic
+pnpm basic
 ```
 
 確認内容:
@@ -29,12 +31,12 @@ npm run basic
 - 話者の指定
 - 速度の変更
 
-### キューテスト (queue.ts)
+### キューテスト (queue/index.ts)
 
 複数テキストの連続再生とキュー動作の確認。
 
 ```bash
-npm run queue
+pnpm queue
 ```
 
 確認内容:
@@ -44,12 +46,12 @@ npm run queue
 - 長短テキストの混在処理
 - 音声パラメータ（音高、抑揚、音量など）の個別設定テスト
 
-### プリフェッチテスト (prefetch.ts)
+### プリフェッチテスト (prefetch/index.ts)
 
 音声生成の先読み（プリフェッチ）機能の確認。
 
 ```bash
-npm run prefetch
+pnpm prefetch
 ```
 
 確認内容:
@@ -57,12 +59,12 @@ npm run prefetch
 - 一括追加時の並列生成
 - 待ち時間の測定
 
-### ファイル生成テスト (file-generation.ts)
+### ファイル生成テスト (file-generation/index.ts)
 
 WAVファイル生成機能の確認。
 
 ```bash
-npm run file
+pnpm file
 ```
 
 確認内容:
@@ -70,13 +72,24 @@ npm run file
 - クエリ経由でのファイル生成
 - 話者/速度の変更
 
+### ファイル再生テスト (file-playback/index.ts)
+
+ストリーミングを使わず、一時ファイル経由で再生するモードの確認。
+
+```bash
+pnpm file-playback
+```
+
+確認内容:
+- `useStreaming: false` での再生
+- 再生モードの判定
 
 ### ブラウザテスト (browser/)
 
 ブラウザ上でvoicevox-clientを使用した音声再生のデモ。
 
 ```bash
-npm run browser
+pnpm browser
 ```
 
 ブラウザで http://localhost:5173 を開いて動作確認できます。

--- a/packages/voicevox-client/README.md
+++ b/packages/voicevox-client/README.md
@@ -1,6 +1,9 @@
 # @kajidog/voicevox-client
 
-A TypeScript client library for VOICEVOX text-to-speech synthesis engine.
+A TypeScript client library for the VOICEVOX text-to-speech engine.
+
+ESM only, with **zero runtime dependencies** — it uses the platform's `fetch` and
+`crypto.randomUUID`. Runs on Node.js >= 18 and in the browser.
 
 ## Installation
 
@@ -50,7 +53,10 @@ const speakers = await client.getSpeakers();
 - **Speaker Management**: Get information about available speakers and voices
 - **Flexible Input**: Support for single text, text arrays, and speech segments
 - **Advanced Playback Control**: Immediate playback, synchronous/asynchronous control
-- **Lightweight**: No external audio dependencies - uses platform-native tools
+- **Prefetching**: Look-ahead synthesis of queued items for gapless playback
+- **Retry & Timeout**: Configurable retry with exponential backoff and a per-request timeout
+- **User Dictionary**: Read and edit the VOICEVOX user dictionary, with inline accent notation
+- **Lightweight**: No runtime dependencies - uses platform-native tools
 
 ## API Reference
 
@@ -68,11 +74,21 @@ new VoicevoxClient(config: VoicevoxConfig)
 
 ```typescript
 interface VoicevoxConfig {
-  url: string;                           // VOICEVOX engine URL
-  defaultSpeaker?: number;               // Default speaker ID (default: 1)
-  defaultSpeedScale?: number;            // Default playback speed (default: 1.0)
+  url: string;                    // VOICEVOX engine URL (required)
+  defaultSpeaker: number;         // Default speaker ID (required)
+  defaultSpeedScale?: number;     // Default playback speed (default: 1.0)
+  defaultVolumeScale?: number;    // Default volume (0.0 - 2.0, default: 1.0)
+  defaultPitchScale?: number;     // Default pitch (-0.15 - 0.15, default: 0.0)
+  defaultPrePhonemeLength?: number;   // Silence before each segment (seconds)
+  defaultPostPhonemeLength?: number;  // Silence after each segment (seconds)
+  maxSegmentLength?: number;      // Max characters per split segment (default: 150)
+  retryCount?: number;            // Retries per failed API request (0 disables, default: 2)
+  retryDelayMs?: number;          // Initial retry delay, exponential backoff (default: 250)
+  timeoutMs?: number;             // Per-request timeout in ms (default: 30000)
+  prefetchSize?: number;          // Max look-ahead items to synthesize (default: 2)
   defaultPlaybackOptions?: PlaybackOptions;  // Default playback options
-  timeoutMs?: number;                    // Per-request timeout in ms (default: 30000)
+  useStreaming?: boolean;         // true: ffplay streaming, false: temp file playback,
+                                  // undefined: env var / auto-detect
 }
 ```
 
@@ -86,7 +102,19 @@ Convert text to speech and play it.
 speak(
   input: string | string[] | SpeechSegment[],
   options?: SpeakOptions
-): Promise<string>
+): Promise<SpeakResult>
+```
+
+**SpeakResult:**
+
+```typescript
+interface SpeakResult {
+  status: 'queued' | 'playing' | 'played' | 'error';
+  mode: 'streaming' | 'file';
+  textPreview: string;
+  segmentCount: number;
+  errorMessage?: string;  // Set when status is 'error'
+}
 ```
 
 **SpeakOptions:**
@@ -170,13 +198,14 @@ Add text or query to the audio generation queue.
 enqueueAudioGeneration(
   input: string | string[] | SpeechSegment[] | AudioQuery,
   options?: SpeakOptions
-): Promise<string>
+): Promise<SpeakResult>
 ```
 
 ##### Other Methods
 
 - `getSpeakers(): Promise<Speaker[]>` - Get list of available speakers
 - `getSpeakerInfo(uuid: string): Promise<SpeakerInfo>` - Get speaker details
+- `checkHealth(): Promise<{ connected: boolean; version?: string; url: string }>` - Check the engine connection
 - `clearQueue(): Promise<void>` - Clear the playback queue
 - `startPlayback(): void` - Start queue playback
 - `pausePlayback(): void` - Pause queue playback
@@ -184,6 +213,70 @@ enqueueAudioGeneration(
 - `getQueueLength(): number` - Get number of items in queue
 - `isQueueEmpty(): boolean` - Check if queue is empty
 - `isPlaying(): boolean` - Check if currently playing
+- `getQueueService(): QueueService` - Access the underlying queue service
+
+##### User Dictionary
+
+All dictionary methods return the full dictionary after the change, as
+`NormalizedDictionaryWord[]` (`{ wordUuid, surface, pronunciation, accentType, notation, priority }`).
+
+- `getDictionary(): Promise<NormalizedDictionaryWord[]>`
+- `addDictionaryWord(input: DictionaryWordInput): Promise<NormalizedDictionaryWord[]>`
+- `addDictionaryWords(inputs: DictionaryWordInput[]): Promise<NormalizedDictionaryWord[]>`
+- `updateDictionaryWord(input: DictionaryWordUpdateInput): Promise<NormalizedDictionaryWord[]>`
+- `updateDictionaryWords(inputs: DictionaryWordUpdateInput[]): Promise<NormalizedDictionaryWord[]>`
+- `deleteDictionaryWord(wordUuid: string): Promise<NormalizedDictionaryWord[]>`
+- `getAccentNotation(text, speaker?): Promise<{ notation: string; accentPhrases: AccentPhrase[] }>`
+
+```typescript
+interface DictionaryWordInput {
+  surface: string;         // The text to match
+  pronunciation: string;   // Katakana, with optional inline accent notation
+  accentType?: number;     // Derived from the notation when omitted
+  priority?: number;
+  wordType?: string;
+}
+
+// DictionaryWordUpdateInput is the same, with a required `wordUuid`
+// and every other field optional (omitted fields keep their value).
+```
+
+## Inline Accent Notation
+
+Pronunciations are exchanged as katakana with an inline accent marker: `,`
+separates accent phrases and `[` marks where the pitch drops after.
+
+```typescript
+// Read back what the engine estimates for a text
+const { notation } = await client.getAccentNotation('こんにちは世界');
+// -> "コン[ニ]チワ,セ[カ]イ"
+
+// Register a word with an explicit accent
+await client.addDictionaryWord({
+  surface: 'VOICEVOX',
+  pronunciation: 'ボイス[ボッ]クス',
+});
+```
+
+The notation helpers are exported for building your own queries:
+
+```typescript
+import {
+  accentPhrasesToNotation,  // AccentPhrase[] -> notation string
+  parseNotation,            // notation string -> ParsedPhrase[]
+  applyNotationAccents,     // apply parsed accents onto an AudioQuery's accent phrases
+} from '@kajidog/voicevox-client';
+
+const query = await client.generateQuery('こんにちは世界');
+query.accent_phrases = applyNotationAccents(
+  parseNotation('コン[ニ]チワ,セ[カ]イ'),
+  query.accent_phrases,
+  query.accent_phrases
+);
+await client.enqueueAudioGeneration(query);
+```
+
+Phrases whose brackets are omitted keep the engine's own accent estimation.
 
 ## Playback Options
 
@@ -244,32 +337,36 @@ For streaming playback (optional):
 
 ## Environment Variables
 
-- `VOICEVOX_URL`: VOICEVOX engine URL (default: `http://localhost:50021`)
-- `VOICEVOX_DEFAULT_SPEAKER`: Default speaker ID (default: `1`)
-- `VOICEVOX_DEFAULT_SPEED_SCALE`: Default playback speed (default: `1.0`)
+The engine URL and the default speaker are constructor options, not environment
+variables. Only the playback defaults are read from the environment (Node.js only),
+and an explicit option always wins over them:
+
 - `VOICEVOX_DEFAULT_IMMEDIATE`: Start playback immediately (default: `true`)
 - `VOICEVOX_DEFAULT_WAIT_FOR_START`: Wait for playback start (default: `false`)
 - `VOICEVOX_DEFAULT_WAIT_FOR_END`: Wait for playback end (default: `false`)
-- `VOICEVOX_STREAMING_PLAYBACK`: Enable streaming playback (default: `true`)
+- `VOICEVOX_STREAMING_PLAYBACK`: Enable streaming playback when `useStreaming` is unset (default: auto-detect)
 
 ## Development
 
 This package is part of the MCP VOICEVOX project. For development:
 
+The monorepo uses **pnpm**; run these from the repository root or with a filter.
+
 ```bash
-# Install dependencies
-npm install
+# Install dependencies (repository root)
+pnpm install
 
 # Build the package
-npm run build
+pnpm --filter @kajidog/voicevox-client build
 
-# Run tests (includes audio playback mocking)
-npm test
+# Run tests (audio playback is mocked)
+pnpm --filter @kajidog/voicevox-client test
 
 # Type checking and linting
-npm run lint
+pnpm --filter @kajidog/voicevox-client typecheck
+pnpm lint
 ```
 
 ## License
 
-MIT License
+ISC


### PR DESCRIPTION
- README (en/ja): document `phrases` inline accent notation and `waitForStart`
  on `voicevox_speak`, list the user dictionary tools, and use the real
  `voicevox_`-prefixed player tool names
- README (en/ja): add `@kajidog/mcp-core` to the package table and replace the
  root `pnpm dev*` commands (which do not exist) with `pnpm --filter` forms
- voicevox-client README: full `VoicevoxConfig`, `SpeakResult` return types,
  dictionary API and accent notation helpers; drop env vars the library never
  reads and fix the license to ISC
- examples README: pnpm instead of npm, correct script paths, add file-playback
- CLAUDE.md: correct the registered tool names (no `generate_query`, tools are
  exposed with the `voicevox_` prefix)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012t5t4KgeeRVg1ph2vNq2w2